### PR TITLE
fix: TypeScript 6.0 対応（CSS import 型宣言・e2e 型除外）

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css" {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
+    "allowArbitraryExtensions": true,
     "plugins": [
       {
         "name": "next"
@@ -34,8 +35,7 @@
     "src/**/*.tsx",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",
-    ".next-e2e/types/**/*.ts",
-    ".next-e2e/dev/types/**/*.ts"
+    ".next-e2e/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## 原因

PR #47 で `@biomejs/biome` などの dev dependencies と合わせて **TypeScript 5.9.3 → 6.0.2** へメジャーバージョンアップされたことで、本番ビルドが失敗するようになった。

## エラー内容

1. `Cannot find module or type declarations for side-effect import of './globals.css'`
   - TS 6.0 で非 JS/TS ファイルの side-effect import が厳格にチェックされるようになった
2. `.next-e2e/dev/types/validator.ts` の型エラー
   - e2e ビルド時に生成されるファイルが TS 6.0 非対応

## 対応内容

| ファイル | 変更内容 |
|----------|---------|
| `src/types/global.d.ts`（新規） | `declare module "*.css" {}` を追加し CSS import の型宣言を提供 |
| `tsconfig.json` | `allowArbitraryExtensions: true` 追加、`.next-e2e/dev/types/**/*.ts` を include から除外 |

ref: #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)