### PR TITLE
[T40] OGP取得時にHTMLエンティティがデコードされない

### DIFF
--- a/src/app/(dashboard)/bookmarks/fetchOgp.test.ts
+++ b/src/app/(dashboard)/bookmarks/fetchOgp.test.ts
@@ -49,6 +49,34 @@ describe("fetchOgp", () => {
     });
   });
 
+  it("タイトルの HTMLエンティティをデコードする", async () => {
+    mockFetch.mockResolvedValue(
+      makeHtmlResponse(
+        '<html><head><meta property="og:title" content="リリースノート &nbsp;|&nbsp; Gemini API" /></head></html>',
+      ),
+    );
+
+    const result = await fetchOgp("https://example.com");
+
+    expect(result.title).toBe("リリースノート  |  Gemini API");
+  });
+
+  it("<title> タグの HTMLエンティティもデコードする", async () => {
+    mockFetch.mockResolvedValue(
+      makeHtmlResponse(`
+        <html>
+          <head>
+            <title>A &amp; B &lt;test&gt;</title>
+          </head>
+        </html>
+      `),
+    );
+
+    const result = await fetchOgp("https://example.com");
+
+    expect(result.title).toBe("A & B <test>");
+  });
+
   it("og:title がない場合 <title> タグからフォールバック取得する", async () => {
     mockFetch.mockResolvedValue(
       makeHtmlResponse(`

--- a/src/app/(dashboard)/bookmarks/fetchOgp.ts
+++ b/src/app/(dashboard)/bookmarks/fetchOgp.ts
@@ -1,5 +1,16 @@
 "use server";
 
+function decodeHtmlEntities(str: string): string {
+  return str
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCharCode(Number.parseInt(code, 16)));
+}
+
 function isAllowedUrl(url: string): boolean {
   let parsed: URL;
   try {
@@ -41,8 +52,9 @@ export async function fetchOgp(
         new RegExp(`<meta[^>]+content=["']([^"']+)["'][^>]+property=["']${property}["']`, "i"),
       )?.[1];
 
-    const title =
+    const rawTitle =
       getMetaContent("og:title") ?? html.match(/<title[^>]*>([^<]+)<\/title>/i)?.[1]?.trim();
+    const title = rawTitle ? decodeHtmlEntities(rawTitle) : undefined;
 
     const rawImage = getMetaContent("og:image");
     let image: string | undefined;


### PR DESCRIPTION
## Summary

- `fetchOgp.ts` に `decodeHtmlEntities` 関数を追加し、OGPから取得したタイトルのHTMLエンティティ（`&nbsp;` / `&amp;` / `&lt;` / `&gt;` / `&quot;` / 数値参照）をデコードするよう修正

## 対象 Issue

Closes #56

## Test plan

- [ ] UT: `npm test` が全件パスすること
- [ ] 手動: `https://ai.google.dev/gemini-api/docs/changelog?hl=ja` をブックマーク登録し、タイトルに `&nbsp;` が含まれないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)