### PR TITLE
[T41] OGP取得中の保存ボタン制御とタイムアウト短縮

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -82,7 +82,7 @@
 | 戻り値 | 条件 |
 |--------|------|
 | `{ title, image }` | 正常取得（image は絶対 URL に解決済み） |
-| `{ error: "取得できませんでした" }` | URLバリデーション失敗（非 http/https・localhost・プライベートIP等）・fetch 失敗・タイムアウト・レスポンス異常 |
+| `{ error: "取得できませんでした" }` | URLバリデーション失敗（非 http/https・localhost・プライベートIP等）・fetch 失敗・タイムアウト（3秒）・レスポンス異常 |
 
 ---
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -99,6 +99,7 @@ flowchart TD
 | 状態 | 条件 | 表示内容 |
 |------|------|---------|
 | Normal | 初期表示 | 空フォーム（編集時は既存値で初期化） |
+| FetchingOgp | OGP取得中 | タイトルラベルに「取得中...」を表示し、保存ボタンを `disabled` |
 | Submitting | フォーム送信中 | 保存ボタンを「保存中...」に変更し `disabled` |
 | ValidationError | クライアントバリデーション失敗 | 各フィールド下にエラーメッセージを表示（`text-red-500`） |
 | Error | Server Action 失敗 | フォーム上部にエラーメッセージを表示（`bg-red-50 text-red-600`） |

--- a/src/app/(dashboard)/bookmarks/BookmarkForm.tsx
+++ b/src/app/(dashboard)/bookmarks/BookmarkForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { fetchOgp } from "./fetchOgp";
 
@@ -28,6 +28,12 @@ export function BookmarkForm({ defaultValues, action }: Props) {
   const [ogImage, setOgImage] = useState(defaultValues?.ogImage ?? "");
   const [fetchingOgp, setFetchingOgp] = useState(false);
 
+  // fetchOgp の await 中に state が更新されても常に最新値を参照するための ref
+  const titleRef = useRef(title);
+  const ogImageRef = useRef(ogImage);
+  useEffect(() => { titleRef.current = title; }, [title]);
+  useEffect(() => { ogImageRef.current = ogImage; }, [ogImage]);
+
   async function handleUrlBlur(e: React.FocusEvent<HTMLInputElement>) {
     const url = e.currentTarget.value.trim();
     if (!url) return;
@@ -40,14 +46,15 @@ export function BookmarkForm({ defaultValues, action }: Props) {
     }
 
     // タイトルと ogImage が両方入力済みの場合は取得しない
-    if (title && ogImage) return;
+    if (titleRef.current && ogImageRef.current) return;
 
     setFetchingOgp(true);
     const result = await fetchOgp(url);
     setFetchingOgp(false);
 
-    if (!title && result.title) setTitle(result.title);
-    if (!ogImage && result.image) setOgImage(result.image);
+    // await 後は ref で最新値を確認（クロージャの stale state を避けるため）
+    if (!titleRef.current && result.title) setTitle(result.title);
+    if (!ogImageRef.current && result.image) setOgImage(result.image);
   }
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
@@ -151,7 +158,7 @@ export function BookmarkForm({ defaultValues, action }: Props) {
       <div className="flex gap-3">
         <button
           type="submit"
-          disabled={submitting}
+          disabled={submitting || fetchingOgp}
           className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
         >
           {submitting ? "保存中..." : "保存"}

--- a/src/app/(dashboard)/bookmarks/fetchOgp.ts
+++ b/src/app/(dashboard)/bookmarks/fetchOgp.ts
@@ -26,7 +26,7 @@ export async function fetchOgp(
   if (!isAllowedUrl(url)) return { error: "取得できませんでした" };
   try {
     const res = await fetch(url, {
-      signal: AbortSignal.timeout(5000),
+      signal: AbortSignal.timeout(3000),
       headers: { "User-Agent": "Mozilla/5.0 (compatible; link-hub-bot/1.0)" },
     });
     if (!res.ok) return { error: "取得できませんでした" };


### PR DESCRIPTION
## Summary

- OGP取得中（`fetchingOgp`）は保存ボタンを `disabled` にし、`fetchOgp` と `createBookmark` Server Actionの競合を防止
- `fetchOgp` のタイムアウトを **5秒 → 3秒** に短縮し、到達不可URLでの待ち時間を改善
- `handleUrlBlur` 内で `await fetchOgp()` 後に `ref` で最新の `title`/`ogImage` 値を参照し、stale closureによるタイトル上書きバグを修正
- `docs/ui.md`・`docs/api.md` を更新

## 対象 Issue

Closes #58

## Test plan

- [x] E2E: `npm run test:e2e` 全33件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)