### PR TITLE
chore(deps-dev): Bump dotenv from 17.4.1 to 17.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "link-hub",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "link-hub",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "hasInstallScript": true,
       "dependencies": {
         "@clerk/nextjs": "^7.0.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^6.0.0",
-        "dotenv": "^17.4.1",
+        "dotenv": "^17.4.2",
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
         "typescript": "^6",
@@ -2969,9 +2969,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
-      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "link-hub",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.0",
-    "dotenv": "^17.4.1",
+    "dotenv": "^17.4.2",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "typescript": "^6",


### PR DESCRIPTION
## Summary

- `dotenv` 17.4.1 → 17.4.2（開発依存のみ、機能変更なし）

## Test plan

- [x] CI（テスト・Vercel ビルド）通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)