### PR TITLE
fix: タグ作成後に入力欄へフォーカスが戻らない不具合を修正

### DIFF
--- a/src/app/(dashboard)/bookmarks/tags/TagsClient.tsx
+++ b/src/app/(dashboard)/bookmarks/tags/TagsClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { useRouter } from "next/navigation";
 
 import { createTag, deleteTag } from "../actions";
@@ -40,11 +41,9 @@ export function TagsClient({ initialTags }: { initialTags: Tag[] }) {
         ),
       );
       setInputValue("");
-      router.refresh();
     } finally {
-      setCreating(false);
-      // setCreating(false) による再レンダリング後にフォーカスを当てる
-      setTimeout(() => inputRef.current?.focus(), 0);
+      flushSync(() => setCreating(false));
+      inputRef.current?.focus();
     }
   }
 


### PR DESCRIPTION
## Summary

- `router.refresh()` の非同期完了による再レンダリングでフォーカスが `BODY` にリセットされる問題を修正
- `flushSync` で `setCreating(false)` を同期適用してから即フォーカスすることで確実にフォーカスを復帰
- 新規タグは `bookmarkCount: 0` 確定のため `router.refresh()` は不要と判断し削除

## Test plan

- [ ] `/bookmarks/tags` でタグ作成後、入力欄にフォーカスが戻ることを確認
- [ ] 連続してタグを作成し、毎回フォーカスが戻ることを確認
- [ ] 同名タグ作成時のエラー表示を確認
- [ ] タグ削除が正常に動作することを確認

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)