### PR TITLE
docs: タグフィルターシナリオを OR 動作に修正

### DIFF
--- a/docs/e2e-scenarios.md
+++ b/docs/e2e-scenarios.md
@@ -121,7 +121,7 @@
 | 1 | `bonjiri@example.com` | シード後にログインして `/bookmarks` にアクセスする | タグフィルターバー表示 | 一覧上部に「Frontend」「Backend」タグが表示される |
 | 2 | `bonjiri@example.com` | 「Frontend」タグをクリックする | 単一タグフィルター | Frontend タグを持つブックマーク（Next.js・Vercel・Neon）のみ表示される |
 | 3 | `bonjiri@example.com` | 「Frontend」と「Backend」を両方クリックする | 複数タグ OR フィルター | Frontend または Backend タグを持つブックマーク（Next.js・Vercel・Prisma・Neon）が表示される |
-| 4 | `bonjiri@example.com` | 「タグなし」フィルターをクリックする | タグなしフィルター | タグのない「GitHub」「Playwright」のみ表示される |
+| 4 | `bonjiri@example.com` | 「全解除」ボタンで選択を解除してから「タグなし」フィルターをクリックする | タグなしフィルター | タグのない「GitHub」「Playwright」のみ表示される |
 | 5 | `bonjiri@example.com` | 複数タグ選択中に「全解除」ボタンをクリックする | フィルター全解除 | 全件表示に戻る |
 
 ---

--- a/docs/e2e-scenarios.md
+++ b/docs/e2e-scenarios.md
@@ -120,7 +120,7 @@
 |---|---------|------|---------|-------|
 | 1 | `bonjiri@example.com` | シード後にログインして `/bookmarks` にアクセスする | タグフィルターバー表示 | 一覧上部に「Frontend」「Backend」タグが表示される |
 | 2 | `bonjiri@example.com` | 「Frontend」タグをクリックする | 単一タグフィルター | Frontend タグを持つブックマーク（Next.js・Vercel・Neon）のみ表示される |
-| 3 | `bonjiri@example.com` | 「Frontend」と「Backend」を両方クリックする | 複数タグ AND フィルター | 両タグを持つ「Neon」のみ表示される |
+| 3 | `bonjiri@example.com` | 「Frontend」と「Backend」を両方クリックする | 複数タグ OR フィルター | Frontend または Backend タグを持つブックマーク（Next.js・Vercel・Prisma・Neon）が表示される |
 | 4 | `bonjiri@example.com` | 「タグなし」フィルターをクリックする | タグなしフィルター | タグのない「GitHub」「Playwright」のみ表示される |
 | 5 | `bonjiri@example.com` | 複数タグ選択中に「全解除」ボタンをクリックする | フィルター全解除 | 全件表示に戻る |
 


### PR DESCRIPTION
## Summary

- `docs/e2e-scenarios.md` タグフィルター #3 の確認観点・期待値を実装（OR 動作）に合わせて修正
- E2E テスト実施結果で「Frontend」「Backend」を両方選択すると4件表示（OR 動作）となり、AND 前提のシナリオと乖離していたため修正

## Test plan

- [ ] `docs/e2e-scenarios.md` タグフィルター #3 が OR 動作の期待値になっていることを確認

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)