### PR TITLE
feat: キーワード検索をリアルタイム絞り込みに変更

### DIFF
--- a/src/app/(dashboard)/bookmarks/BookmarkList.tsx
+++ b/src/app/(dashboard)/bookmarks/BookmarkList.tsx
@@ -284,7 +284,7 @@ export function BookmarkList({
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
-  const isSearching = searchQuery.length > 0;
+  const isSearching = searchQuery.trim().length > 0;
 
   const searchedItems = isSearching
     ? items.filter((bm) => {

--- a/src/app/(dashboard)/bookmarks/BookmarkList.tsx
+++ b/src/app/(dashboard)/bookmarks/BookmarkList.tsx
@@ -570,7 +570,7 @@ export function BookmarkList({
 
       {filteredItems.length === 0 ? (
         <div className="rounded-lg border border-dashed border-gray-300 py-12 text-center text-sm text-gray-500 dark:border-gray-600 dark:text-gray-400">
-          該当するブックマークがありません
+          {items.length === 0 ? "まだブックマークがありません" : "該当するブックマークがありません"}
         </div>
       ) : mounted ? (
         // クライアントマウント後: DnD 有効

--- a/src/app/(dashboard)/bookmarks/BookmarkList.tsx
+++ b/src/app/(dashboard)/bookmarks/BookmarkList.tsx
@@ -518,6 +518,7 @@ export function BookmarkList({
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
         placeholder="タイトル・URL・メモで検索"
+        aria-label="ブックマークを検索"
         className="mb-4 w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400"
       />
 

--- a/src/app/(dashboard)/bookmarks/BookmarkList.tsx
+++ b/src/app/(dashboard)/bookmarks/BookmarkList.tsx
@@ -287,14 +287,15 @@ export function BookmarkList({
   const isSearching = searchQuery.trim().length > 0;
 
   const searchedItems = isSearching
-    ? items.filter((bm) => {
+    ? (() => {
         const q = searchQuery.toLowerCase();
-        return (
-          bm.title.toLowerCase().includes(q) ||
-          bm.url.toLowerCase().includes(q) ||
-          (bm.memo?.toLowerCase().includes(q) ?? false)
+        return items.filter(
+          (bm) =>
+            bm.title.toLowerCase().includes(q) ||
+            bm.url.toLowerCase().includes(q) ||
+            (bm.memo?.toLowerCase().includes(q) ?? false),
         );
-      })
+      })()
     : items;
 
   const filteredItems =

--- a/src/app/(dashboard)/bookmarks/BookmarkList.tsx
+++ b/src/app/(dashboard)/bookmarks/BookmarkList.tsx
@@ -243,15 +243,14 @@ function ItemContent({
 
 export function BookmarkList({
   bookmarks: initial,
-  isSearching,
   allTags,
 }: {
   bookmarks: Bookmark[];
-  isSearching: boolean;
   allTags: TagFilterItem[];
 }) {
   const router = useRouter();
   const [mounted, setMounted] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const [items, setItems] = useState<Bookmark[]>(initial);
   const [allTagsState, setAllTagsState] = useState<TagFilterItem[]>(allTags);
   const [activeTagIds, setActiveTagIds] = useState<string[]>([]);
@@ -285,10 +284,23 @@ export function BookmarkList({
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
+  const isSearching = searchQuery.length > 0;
+
+  const searchedItems = isSearching
+    ? items.filter((bm) => {
+        const q = searchQuery.toLowerCase();
+        return (
+          bm.title.toLowerCase().includes(q) ||
+          bm.url.toLowerCase().includes(q) ||
+          (bm.memo?.toLowerCase().includes(q) ?? false)
+        );
+      })
+    : items;
+
   const filteredItems =
     activeTagIds.length === 0
-      ? items
-      : items.filter((bm) => {
+      ? searchedItems
+      : searchedItems.filter((bm) => {
           if (activeTagIds.includes(UNTAGGED_ID) && bm.tags.length === 0) return true;
           return activeTagIds.some(
             (tid) => tid !== UNTAGGED_ID && bm.tags.some((bt) => bt.tagId === tid),
@@ -500,6 +512,14 @@ export function BookmarkList({
 
   return (
     <div>
+      <input
+        type="search"
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+        placeholder="タイトル・URL・メモで検索"
+        className="mb-4 w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400"
+      />
+
       <TagFilter
         tags={allTagsState}
         selectedTagIds={activeTagIds}
@@ -547,7 +567,7 @@ export function BookmarkList({
         />
       )}
 
-      {filteredItems.length === 0 && activeTagIds.length > 0 ? (
+      {filteredItems.length === 0 ? (
         <div className="rounded-lg border border-dashed border-gray-300 py-12 text-center text-sm text-gray-500 dark:border-gray-600 dark:text-gray-400">
           該当するブックマークがありません
         </div>

--- a/src/app/(dashboard)/bookmarks/page.tsx
+++ b/src/app/(dashboard)/bookmarks/page.tsx
@@ -6,19 +6,12 @@ import { getBookmarks } from "@/lib/bookmarks";
 import { getTags } from "@/lib/tags";
 import { BookmarkList } from "./BookmarkList";
 
-export default async function BookmarksPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ q?: string }>;
-}) {
+export default async function BookmarksPage() {
   const session = await getSession();
   if (!session) redirect("/sign-in");
 
-  const { q } = await searchParams;
-  const query = q?.trim() ?? "";
-
   const [bookmarks, tags] = await Promise.all([
-    getBookmarks(session.user.id, query || undefined),
+    getBookmarks(session.user.id),
     getTags(session.user.id),
   ]);
 
@@ -42,22 +35,12 @@ export default async function BookmarksPage({
         </div>
       </div>
 
-      <form method="get" className="mb-4">
-        <input
-          type="search"
-          name="q"
-          defaultValue={query}
-          placeholder="タイトル・URL・メモで検索"
-          className="w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400"
-        />
-      </form>
-
       {bookmarks.length === 0 ? (
         <div className="rounded-lg border border-dashed border-gray-300 py-16 text-center text-gray-500 dark:border-gray-600 dark:text-gray-400">
-          {query ? "該当するブックマークがありません" : "まだブックマークがありません"}
+          まだブックマークがありません
         </div>
       ) : (
-        <BookmarkList key={query} bookmarks={bookmarks} isSearching={!!query} allTags={tags} />
+        <BookmarkList bookmarks={bookmarks} allTags={tags} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- 検索をサーバーサイド（`?q=` URL パラメータ + DB フィルタリング）からクライアントサイドフィルタリングに移行
- `BookmarkList` 内に検索 input を追加し、`onChange` で即時絞り込みを実現
- Enter キー操作が不要になり、`docs/e2e-scenarios.md` のキーワード検索シナリオ仕様に合致

## Test plan

- [ ] 検索欄に入力すると Enter 不要でリアルタイムに絞り込まれることを確認
- [ ] タイトル・URL・メモの部分一致で絞り込まれることを確認
- [ ] 検索欄を空にすると全件表示に戻ることを確認
- [ ] 検索中はドラッグハンドルが非表示・背景が薄青になることを確認

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)