### PR TITLE
feat: README バッジ追加・自動PR ワークフロー追加・Actions バージョン更新

### DIFF
--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -1,0 +1,119 @@
+name: Auto PR develop → master
+
+on:
+  schedule:
+    - cron: '0 21 * * *' # JST AM6:00 (UTC 21:00)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: auto-pr-develop-to-master
+  cancel-in-progress: false
+
+jobs:
+  auto-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check diff between develop and master
+        id: diff
+        run: |
+          git fetch origin
+          COUNT=$(git log origin/master..origin/develop --oneline | wc -l | tr -d ' ')
+          if [ "$COUNT" -gt 0 ]; then
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+            echo "差分あり: ${COUNT} コミット"
+          else
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+            echo "差分なし。スキップします。"
+          fi
+
+      - name: Determine bump label and build PR body
+        id: content
+        if: steps.diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LABEL="bump:patch"
+          ISSUES_SECTION=""
+
+          # コミットメッセージから Issue 番号を抽出
+          ISSUE_NUMBERS=$(git log origin/master..origin/develop --format="%B" \
+            | grep -oE '(Closes|Fixes|closes|fixes) #[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | sort -u)
+
+          for NUM in $ISSUE_NUMBERS; do
+            ISSUE_DATA=$(gh issue view "$NUM" --json title,labels 2>/dev/null) || continue
+            ISSUE_TITLE=$(echo "$ISSUE_DATA" | jq -r '.title')
+            ISSUE_LABELS=$(echo "$ISSUE_DATA" | jq -r '.labels[].name')
+
+            ISSUES_SECTION="${ISSUES_SECTION}- #${NUM} ${ISSUE_TITLE}\n"
+
+            # enhancement ラベルがあれば bump:minor に昇格
+            if echo "$ISSUE_LABELS" | grep -q "^enhancement$"; then
+              LABEL="bump:minor"
+            fi
+          done
+
+          # Dependabot コミットが含まれる場合はログに記録（patch のまま）
+          if git log origin/master..origin/develop --format="%s" | grep -q "^chore(deps"; then
+            echo "Dependabot コミットを検出 → bump:patch"
+          fi
+
+          # PR 本文を生成
+          {
+            echo "## 概要"
+            echo ""
+            echo "develop ブランチの変更を master にマージします。"
+            echo ""
+            if [ -n "$ISSUES_SECTION" ]; then
+              echo "## 含まれる Issue"
+              echo ""
+              printf "%b" "$ISSUES_SECTION"
+            else
+              echo "## 含まれる変更"
+              echo ""
+              git log origin/master..origin/develop --oneline | head -10 | sed 's/^/- /'
+            fi
+            echo ""
+            echo "🤖 このPRは自動生成されました"
+          } > /tmp/pr_body.md
+
+          echo "label=$LABEL" >> "$GITHUB_OUTPUT"
+          echo "判定ラベル: $LABEL"
+
+      - name: Create or update PR
+        if: steps.diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LABEL="${{ steps.content.outputs.label }}"
+          EXISTING_PR=$(gh pr list --base master --head develop --state open --json number --jq '.[0].number')
+
+          if [ -z "$EXISTING_PR" ]; then
+            gh pr create \
+              --base master \
+              --head develop \
+              --title "chore: develop → master $(TZ=Asia/Tokyo date +'%Y-%m-%d')" \
+              --body-file /tmp/pr_body.md \
+              --label "$LABEL"
+            echo "✅ PR を新規作成しました（ラベル: $LABEL）"
+          else
+            # 本文を更新
+            gh pr edit "$EXISTING_PR" --body-file /tmp/pr_body.md
+
+            # ラベルを差し替え
+            gh pr edit "$EXISTING_PR" --remove-label "bump:minor" 2>/dev/null || true
+            gh pr edit "$EXISTING_PR" --remove-label "bump:patch" 2>/dev/null || true
+            gh pr edit "$EXISTING_PR" --add-label "$LABEL"
+
+            echo "✅ PR #${EXISTING_PR} を更新しました（ラベル: $LABEL）"
+          fi

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -14,14 +14,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Bump version
         id: bump

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.tag_check.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # link-hub
 
+![CI](https://github.com/ot-nemoto/link-hub/actions/workflows/ci.yml/badge.svg)
+![Version](https://img.shields.io/github/package-json/v/ot-nemoto/link-hub)
+![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js)
+![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white)
+![Prisma](https://img.shields.io/badge/Prisma-7-2D3748?logo=prisma&logoColor=white)
+![Clerk](https://img.shields.io/badge/Clerk-Auth-6C47FF?logo=clerk&logoColor=white)
+![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-4-06B6D4?logo=tailwindcss&logoColor=white)
+
 アカウントごとにブックマークを管理するシンプルな Web アプリケーションです。
 
 ## 機能


### PR DESCRIPTION
## Summary

- README.md にCI/Version/技術スタックバッジを追加
- `.github/workflows/auto-pr-to-master.yml` を新規作成（毎日JST AM6:00に develop→master の差分チェック＆自動PR作成・更新）
- 全ワークフローの `actions/checkout`・`actions/setup-node` を v4→v5 に更新
- `softprops/action-gh-release` を v2→v3 に更新
- `node-version` を 20→24 に更新

## Related Issues

- Closes #119 [T65] README にバッジを追加する
- Closes #120 [T66] develop → master の自動 PR 作成ワークフローを追加する
- Closes #121 [T67] GitHub Actions のアクションバージョンを Node.js 24 対応版に更新する

## Test plan

- [ ] CI が正常に通過することを確認
- [ ] README のバッジが GitHub 上で正しく表示されることを確認
- [ ] `auto-pr-to-master.yml` を `workflow_dispatch` で手動実行し、PRが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)