### PR TITLE
fix: auto-pr-to-master を AUTO_PR_TOKEN に切り替えて CI・Bump を自動発火させる

### DIFF
--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -39,7 +39,7 @@ jobs:
         id: content
         if: steps.diff.outputs.has_diff == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_PR_TOKEN }}
         run: |
           LABEL="bump:patch"
           ISSUES_SECTION=""
@@ -93,7 +93,7 @@ jobs:
       - name: Create or update PR
         if: steps.diff.outputs.has_diff == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_PR_TOKEN }}
         run: |
           LABEL="${{ steps.content.outputs.label }}"
           EXISTING_PR=$(gh pr list --base master --head develop --state open --json number --jq '.[0].number')


### PR DESCRIPTION
## Summary

- `auto-pr-to-master.yml` の `GH_TOKEN` を `GITHUB_TOKEN` → `AUTO_PR_TOKEN` に変更（2箇所）
- これにより `github-actions[bot]` が作成した PR でも CI・bump-version が自動発火するようになる

## Related Issues

- Closes #125 [T69] auto-pr-to-master を PAT 使用に変更し CI・Bump を自動発火させる

## Test plan

- [ ] CI が正常に通過することを確認
- [ ] マージ後、`auto-pr-to-master.yml` を `workflow_dispatch` で手動実行し、新しい PR で CI・bump-version が自動発火することを確認

## 対応方針

PR #123（`GITHUB_TOKEN` で自動生成された develop→master PR）は本 PR マージ後にクローズし、`workflow_dispatch` で再作成する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)