### PR TITLE
fix: bump-version.yml のコミットメッセージに [skip ci] を追加

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -36,5 +36,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json package-lock.json
-          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }} [skip ci]"
           git push


### PR DESCRIPTION
## Summary

- `bump-version.yml` のバンプコミットメッセージに `[skip ci]` を追加
- これによりバンプコミットのプッシュ後に CI が `action_required` になるのを防ぐ

## Related Issues

- Closes #130 [T70] bump-version.yml のコミットメッセージに [skip ci] を追加する

## Test plan

- [ ] CI が正常に通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)