### PR TITLE
fix: [T71] PR description の Closes 参照も bump ラベル判定に含める

### DIFF
--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -47,8 +47,20 @@ jobs:
           # コミットメッセージから Issue 番号を抽出
           ISSUE_NUMBERS=$(git log origin/master..origin/develop --format="%B" \
             | grep -oE '(Closes|Fixes|closes|fixes) #[0-9]+' \
-            | grep -oE '[0-9]+' \
-            | sort -u)
+            | grep -oE '[0-9]+')
+
+          # マージコミットの PR description からも Issue 番号を抽出
+          PR_NUMBERS=$(git log origin/master..origin/develop --format="%s" \
+            | grep -oE 'pull request #[0-9]+' \
+            | grep -oE '[0-9]+')
+          for PR_NUM in $PR_NUMBERS; do
+            PR_CLOSES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUM}" --jq '.body // ""' 2>/dev/null \
+              | grep -oE '(Closes|Fixes|closes|fixes) #[0-9]+' \
+              | grep -oE '[0-9]+')
+            ISSUE_NUMBERS="${ISSUE_NUMBERS} ${PR_CLOSES}"
+          done
+
+          ISSUE_NUMBERS=$(echo "$ISSUE_NUMBERS" | tr ' ' '\n' | grep -v '^$' | sort -u)
 
           for NUM in $ISSUE_NUMBERS; do
             ISSUE_DATA=$(gh issue view "$NUM" --json title,labels 2>/dev/null) || continue


### PR DESCRIPTION
## 概要

`auto-pr-to-master.yml` の bump ラベル判定ロジックが PR description の `Closes #N` を拾えない問題を修正。

## 変更内容

- コミットメッセージからの Issue 抽出（既存）に加え、マージコミットから PR 番号を取得
- 各 PR の description も `Closes #N` の検索対象に追加

## 参考

- account-sql-generator [T18](https://github.com/ot-nemoto/account-sql-generator/issues/48) と同様の対応

Closes #139