### PR TITLE
chore: develop → master 2026-04-27

### DIFF
--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -47,8 +47,20 @@ jobs:
           # コミットメッセージから Issue 番号を抽出
           ISSUE_NUMBERS=$(git log origin/master..origin/develop --format="%B" \
             | grep -oE '(Closes|Fixes|closes|fixes) #[0-9]+' \
-            | grep -oE '[0-9]+' \
-            | sort -u)
+            | grep -oE '[0-9]+')
+
+          # マージコミットの PR description からも Issue 番号を抽出
+          PR_NUMBERS=$(git log origin/master..origin/develop --format="%s" \
+            | grep -oE 'pull request #[0-9]+' \
+            | grep -oE '[0-9]+')
+          for PR_NUM in $PR_NUMBERS; do
+            PR_CLOSES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUM}" --jq '.body // ""' 2>/dev/null \
+              | grep -oE '(Closes|Fixes|closes|fixes) #[0-9]+' \
+              | grep -oE '[0-9]+')
+            ISSUE_NUMBERS="${ISSUE_NUMBERS} ${PR_CLOSES}"
+          done
+
+          ISSUE_NUMBERS=$(echo "$ISSUE_NUMBERS" | tr ' ' '\n' | grep -v '^$' | sort -u)
 
           for NUM in $ISSUE_NUMBERS; do
             ISSUE_DATA=$(gh issue view "$NUM" --json title,labels 2>/dev/null) || continue

--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -47,20 +47,21 @@ jobs:
           # コミットメッセージから Issue 番号を抽出
           ISSUE_NUMBERS=$(git log origin/master..origin/develop --format="%B" \
             | grep -oE '(Closes|Fixes|closes|fixes) #[0-9]+' \
-            | grep -oE '[0-9]+')
+            | grep -oE '[0-9]+' || true)
 
           # マージコミットの PR description からも Issue 番号を抽出
           PR_NUMBERS=$(git log origin/master..origin/develop --format="%s" \
             | grep -oE 'pull request #[0-9]+' \
-            | grep -oE '[0-9]+')
+            | grep -oE '[0-9]+' \
+            | sort -u || true)
           for PR_NUM in $PR_NUMBERS; do
             PR_CLOSES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUM}" --jq '.body // ""' 2>/dev/null \
               | grep -oE '(Closes|Fixes|closes|fixes) #[0-9]+' \
-              | grep -oE '[0-9]+')
+              | grep -oE '[0-9]+' || true)
             ISSUE_NUMBERS="${ISSUE_NUMBERS} ${PR_CLOSES}"
           done
 
-          ISSUE_NUMBERS=$(echo "$ISSUE_NUMBERS" | tr ' ' '\n' | grep -v '^$' | sort -u)
+          ISSUE_NUMBERS=$(echo "$ISSUE_NUMBERS" | tr ' ' '\n' | grep -v '^$' | sort -u || true)
 
           for NUM in $ISSUE_NUMBERS; do
             ISSUE_DATA=$(gh issue view "$NUM" --json title,labels 2>/dev/null) || continue

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "link-hub",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "link-hub",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "hasInstallScript": true,
       "dependencies": {
         "@clerk/nextjs": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "link-hub",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## 概要

develop ブランチの変更を master にマージします。

## 含まれる Issue

- #139 [T71] auto-pr-to-master の bump ラベル判定が PR description の Closes 参照を拾えない問題を修正
- #141 [T72] auto-pr-to-master の grep コマンドに || true を追加してスクリプト失敗を防ぐ

🤖 このPRは自動生成されました