### PR TITLE
fix: [T74] .env.local を廃止して .env に統一する

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -23,7 +23,7 @@ Clerk によるメール/パスワード認証を使用する。
 
 ### 開発環境のモックバイパス
 
-`.env.local` に `MOCK_USER_ID` または `MOCK_USER_EMAIL` が設定されている場合、middleware の認証チェックをスキップする（本番環境では無効）。
+`.env` に `MOCK_USER_ID` または `MOCK_USER_EMAIL` が設定されている場合、middleware の認証チェックをスキップする（本番環境では無効）。
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@
 # 1. 依存パッケージのインストール
 npm install
 
-# 2. .env.local を作成し、環境変数を設定する（下の「環境変数」節を参照）
+# 2. .env を作成し、環境変数を設定する（下の「環境変数」節を参照）
 #    ※ DATABASE_URL・DIRECT_URL の設定が必須
 
 # 3. Prisma クライアントの生成（DIRECT_URL の設定が必要）
@@ -28,7 +28,7 @@ npm run dev
 
 ## 環境変数
 
-`.env.local` をプロジェクトルートに作成し、以下の変数を設定する。
+`.env` をプロジェクトルートに作成し、以下の変数を設定する。
 
 ```env
 # Database（Neon）
@@ -50,7 +50,7 @@ NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/bookmarks
 
 ### ローカル開発用認証バイパス
 
-Clerk 認証なしで動作確認するため、`MOCK_USER_ID` または `MOCK_USER_EMAIL` を `.env.local` に設定する。
+Clerk 認証なしで動作確認するため、`MOCK_USER_ID` または `MOCK_USER_EMAIL` を `.env` に設定する。
 
 ```env
 # DB の users.id を指定する場合
@@ -108,7 +108,7 @@ bonjiri のブックマークとタグの対応：
 
 - Clerk にユーザーが存在しない場合は自動作成される（パスワード: `Yakitori2026`）
 - 既存のブックマーク・タグは全削除されるため、手動で追加したデータは失われる
-- `CLERK_SECRET_KEY` が `.env.local` に設定されていること
+- `CLERK_SECRET_KEY` が `.env` に設定されていること
 
 ---
 

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "prisma/config";
 import * as dotenv from "dotenv";
 
-dotenv.config({ path: ".env.local" });
+dotenv.config({ path: ".env" });
 
 export default defineConfig({
   schema: "prisma/schema.prisma",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -10,7 +10,7 @@ import { PrismaNeon } from "@prisma/adapter-neon";
 import { PrismaClient } from "@prisma/client";
 import * as dotenv from "dotenv";
 
-dotenv.config({ path: ".env.local" });
+dotenv.config({ path: ".env" });
 
 const adapter = new PrismaNeon({ connectionString: process.env.DIRECT_URL ?? "" });
 const prisma = new PrismaClient({ adapter });


### PR DESCRIPTION
## 概要

`.env.local` への参照を廃止し、`.env` に統一します。

## 変更内容

| ファイル | 変更 |
|----------|------|
| `prisma.config.ts` | `dotenv.config` のパスを `.env.local` → `.env` に変更 |
| `prisma/seed.ts` | `dotenv.config` のパスを `.env.local` → `.env` に変更 |
| `docs/development.md` | `.env.local` 記述を `.env` に更新（4箇所） |
| `docs/auth.md` | `.env.local` 記述を `.env` に更新（1箇所） |
| `.env.local` | ファイル削除（git管理外） |

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)