### PR TITLE
fix: biome フォーマット修正（インポート順・JSX 整形）

### DIFF
--- a/src/app/(dashboard)/bookmarks/BookmarkForm.tsx
+++ b/src/app/(dashboard)/bookmarks/BookmarkForm.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
 import { fetchOgp } from "./fetchOgp";
-import { TagInput, type Tag } from "./TagInput";
+import { type Tag, TagInput } from "./TagInput";
 
 type Props = {
   availableTags: Tag[];
@@ -43,8 +43,12 @@ export function BookmarkForm({ availableTags, defaultValues, action }: Props) {
 
   const titleRef = useRef(title);
   const ogImageRef = useRef(ogImage);
-  useEffect(() => { titleRef.current = title; }, [title]);
-  useEffect(() => { ogImageRef.current = ogImage; }, [ogImage]);
+  useEffect(() => {
+    titleRef.current = title;
+  }, [title]);
+  useEffect(() => {
+    ogImageRef.current = ogImage;
+  }, [ogImage]);
 
   async function handleUrlBlur(e: React.FocusEvent<HTMLInputElement>) {
     const url = e.currentTarget.value.trim();

--- a/src/app/(dashboard)/bookmarks/BookmarkList.tsx
+++ b/src/app/(dashboard)/bookmarks/BookmarkList.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import {
+  closestCenter,
   DndContext,
+  type DragEndEvent,
   KeyboardSensor,
   PointerSensor,
-  closestCenter,
   useSensor,
   useSensors,
-  type DragEndEvent,
 } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -18,12 +18,12 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { bulkAddTags, deleteBookmark, deleteBookmarks, reorderBookmarks } from "./actions";
 import { BulkTagPanel } from "./BulkTagPanel";
 import { InlineTagEditor } from "./InlineTagEditor";
-import { TagFilter, UNTAGGED_ID, type TagFilterItem } from "./TagFilter";
+import { TagFilter, type TagFilterItem, UNTAGGED_ID } from "./TagFilter";
 import { UndoSnackbar } from "./UndoSnackbar";
-import { bulkAddTags, deleteBookmark, deleteBookmarks, reorderBookmarks } from "./actions";
 
 type BookmarkTag = { tagId: string; tag: { id: string; name: string } };
 
@@ -72,7 +72,18 @@ type ItemProps = {
   onEditTagsCancel: () => void;
 };
 
-function PlainItem({ bm, isDndDisabled, isSelected, onToggleSelect, onDelete, allTags, editingTags, onEditTagsStart, onEditTagsSave, onEditTagsCancel }: ItemProps) {
+function PlainItem({
+  bm,
+  isDndDisabled,
+  isSelected,
+  onToggleSelect,
+  onDelete,
+  allTags,
+  editingTags,
+  onEditTagsStart,
+  onEditTagsSave,
+  onEditTagsCancel,
+}: ItemProps) {
   return (
     <li className="flex items-center gap-3 px-4 py-3 bg-white">
       {isDndDisabled ? null : (
@@ -87,12 +98,31 @@ function PlainItem({ bm, isDndDisabled, isSelected, onToggleSelect, onDelete, al
         className="h-4 w-4 shrink-0 cursor-pointer"
         aria-label={`${bm.title}を選択`}
       />
-      <ItemContent bm={bm} onDelete={onDelete} allTags={allTags} editingTags={editingTags} onEditTagsStart={onEditTagsStart} onEditTagsSave={onEditTagsSave} onEditTagsCancel={onEditTagsCancel} />
+      <ItemContent
+        bm={bm}
+        onDelete={onDelete}
+        allTags={allTags}
+        editingTags={editingTags}
+        onEditTagsStart={onEditTagsStart}
+        onEditTagsSave={onEditTagsSave}
+        onEditTagsCancel={onEditTagsCancel}
+      />
     </li>
   );
 }
 
-function SortableItem({ bm, isDndDisabled, isSelected, onToggleSelect, onDelete, allTags, editingTags, onEditTagsStart, onEditTagsSave, onEditTagsCancel }: ItemProps) {
+function SortableItem({
+  bm,
+  isDndDisabled,
+  isSelected,
+  onToggleSelect,
+  onDelete,
+  allTags,
+  editingTags,
+  onEditTagsStart,
+  onEditTagsSave,
+  onEditTagsCancel,
+}: ItemProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: bm.id,
     disabled: isDndDisabled,
@@ -105,11 +135,7 @@ function SortableItem({ bm, isDndDisabled, isSelected, onToggleSelect, onDelete,
   };
 
   return (
-    <li
-      ref={setNodeRef}
-      style={style}
-      className="flex items-center gap-3 px-4 py-3 bg-white"
-    >
+    <li ref={setNodeRef} style={style} className="flex items-center gap-3 px-4 py-3 bg-white">
       {!isDndDisabled && (
         <button
           type="button"
@@ -128,7 +154,15 @@ function SortableItem({ bm, isDndDisabled, isSelected, onToggleSelect, onDelete,
         className="h-4 w-4 shrink-0 cursor-pointer"
         aria-label={`${bm.title}を選択`}
       />
-      <ItemContent bm={bm} onDelete={onDelete} allTags={allTags} editingTags={editingTags} onEditTagsStart={onEditTagsStart} onEditTagsSave={onEditTagsSave} onEditTagsCancel={onEditTagsCancel} />
+      <ItemContent
+        bm={bm}
+        onDelete={onDelete}
+        allTags={allTags}
+        editingTags={editingTags}
+        onEditTagsStart={onEditTagsStart}
+        onEditTagsSave={onEditTagsSave}
+        onEditTagsCancel={onEditTagsCancel}
+      />
     </li>
   );
 }
@@ -162,9 +196,7 @@ function ItemContent({
           {bm.title}
         </a>
         <p className="truncate text-xs text-zinc-400">{bm.url}</p>
-        {bm.memo && (
-          <p className="truncate text-sm text-zinc-600">{bm.memo}</p>
-        )}
+        {bm.memo && <p className="truncate text-sm text-zinc-600">{bm.memo}</p>}
         <div className="mt-1 flex flex-wrap items-center gap-1">
           {bm.tags.map((bt) => {
             const tagName = allTags.find((t) => t.id === bt.tagId)?.name ?? bt.tag.name;
@@ -242,11 +274,19 @@ export function BookmarkList({
   const [pending, setPending] = useState<PendingDelete | null>(null);
   const pendingRef = useRef<PendingDelete | null>(null);
 
-  useEffect(() => { setMounted(true); }, []);
-  useEffect(() => { setItems(initial); }, [initial]);
-  useEffect(() => { setAllTagsState(allTags); }, [allTags]);
   useEffect(() => {
-    return () => { if (pendingRef.current) clearTimeout(pendingRef.current.timerId); };
+    setMounted(true);
+  }, []);
+  useEffect(() => {
+    setItems(initial);
+  }, [initial]);
+  useEffect(() => {
+    setAllTagsState(allTags);
+  }, [allTags]);
+  useEffect(() => {
+    return () => {
+      if (pendingRef.current) clearTimeout(pendingRef.current.timerId);
+    };
   }, []);
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -288,9 +328,7 @@ export function BookmarkList({
 
   const toggleAll = useCallback(() => {
     setSelectedIds((prev) =>
-      prev.size === filteredItems.length
-        ? new Set()
-        : new Set(filteredItems.map((b) => b.id)),
+      prev.size === filteredItems.length ? new Set() : new Set(filteredItems.map((b) => b.id)),
     );
   }, [filteredItems]);
 
@@ -359,9 +397,10 @@ export function BookmarkList({
     (bookmarkId: string, tagIds: string[], newTags: TagFilterItem[]) => {
       const nextAllTags =
         newTags.length > 0
-          ? [...allTagsState, ...newTags.filter((t) => !allTagsState.find((a) => a.id === t.id))].sort(
-              (a, b) => a.name.localeCompare(b.name),
-            )
+          ? [
+              ...allTagsState,
+              ...newTags.filter((t) => !allTagsState.find((a) => a.id === t.id)),
+            ].sort((a, b) => a.name.localeCompare(b.name))
           : allTagsState;
       if (newTags.length > 0) setAllTagsState(nextAllTags);
       setItems((prev) =>
@@ -424,7 +463,9 @@ export function BookmarkList({
   );
 
   const itemsRef = useRef<Bookmark[]>(initial);
-  useEffect(() => { itemsRef.current = items; }, [items]);
+  useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
 
   const handleDragEndWithSave = useCallback(async (event: DragEndEvent) => {
     const { active, over } = event;
@@ -473,11 +514,7 @@ export function BookmarkList({
         className="mb-4 w-full rounded-md border border-zinc-300 px-4 py-2 text-sm shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
       />
 
-      <TagFilter
-        tags={allTagsState}
-        selectedTagIds={activeTagIds}
-        onChange={setActiveTagIds}
-      />
+      <TagFilter tags={allTagsState} selectedTagIds={activeTagIds} onChange={setActiveTagIds} />
 
       <div className="mb-3 flex items-center gap-2">
         <button
@@ -489,9 +526,7 @@ export function BookmarkList({
         </button>
         {selectedIds.size > 0 && (
           <>
-            <span className="text-sm text-zinc-500">
-              {selectedIds.size}件選択中
-            </span>
+            <span className="text-sm text-zinc-500">{selectedIds.size}件選択中</span>
             <button
               type="button"
               onClick={() => setIsBulkTagging((prev) => !prev)}
@@ -516,7 +551,10 @@ export function BookmarkList({
           saving={bulkTagSaving}
           error={bulkTagError}
           onSave={handleBulkTagsSave}
-          onCancel={() => { setIsBulkTagging(false); setBulkTagError(""); }}
+          onCancel={() => {
+            setIsBulkTagging(false);
+            setBulkTagError("");
+          }}
         />
       )}
 
@@ -530,7 +568,10 @@ export function BookmarkList({
           collisionDetection={closestCenter}
           onDragEnd={handleDragEndWithSave}
         >
-          <SortableContext items={filteredItems.map((b) => b.id)} strategy={verticalListSortingStrategy}>
+          <SortableContext
+            items={filteredItems.map((b) => b.id)}
+            strategy={verticalListSortingStrategy}
+          >
             <ul className="divide-y divide-zinc-100 rounded-lg border border-zinc-200">
               {filteredItems.map((bm) => (
                 <SortableItem key={bm.id} {...itemProps(bm)} />

--- a/src/app/(dashboard)/bookmarks/BulkTagPanel.tsx
+++ b/src/app/(dashboard)/bookmarks/BulkTagPanel.tsx
@@ -16,20 +16,14 @@ export function BulkTagPanel({ allTags, saving, error, onSave, onCancel }: Props
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
 
   function toggle(id: string) {
-    setSelectedTagIds((prev) =>
-      prev.includes(id) ? prev.filter((t) => t !== id) : [...prev, id],
-    );
+    setSelectedTagIds((prev) => (prev.includes(id) ? prev.filter((t) => t !== id) : [...prev, id]));
   }
 
   return (
     <div className="mb-3 rounded-lg bg-white p-4 shadow-sm border border-zinc-200">
-      <p className="mb-2 text-sm font-medium text-zinc-700">
-        追加するタグを選択
-      </p>
+      <p className="mb-2 text-sm font-medium text-zinc-700">追加するタグを選択</p>
       {allTags.length === 0 ? (
-        <p className="mb-3 text-sm text-zinc-500">
-          タグがありません。先にタグを作成してください。
-        </p>
+        <p className="mb-3 text-sm text-zinc-500">タグがありません。先にタグを作成してください。</p>
       ) : (
         <div className="mb-3 flex flex-wrap gap-2">
           {allTags.map((tag) => {
@@ -40,9 +34,7 @@ export function BulkTagPanel({ allTags, saving, error, onSave, onCancel }: Props
                 type="button"
                 onClick={() => toggle(tag.id)}
                 className={`cursor-pointer rounded-full px-3 py-1 text-sm font-medium ${
-                  active
-                    ? "bg-zinc-900 text-white"
-                    : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200"
+                  active ? "bg-zinc-900 text-white" : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200"
                 }`}
               >
                 {tag.name}

--- a/src/app/(dashboard)/bookmarks/InlineTagEditor.tsx
+++ b/src/app/(dashboard)/bookmarks/InlineTagEditor.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 
 import { updateBookmarkTags } from "./actions";
-import { TagInput, type Tag } from "./TagInput";
+import { type Tag, TagInput } from "./TagInput";
 
 type Props = {
   bookmarkId: string;
@@ -13,13 +13,7 @@ type Props = {
   onCancel: () => void;
 };
 
-export function InlineTagEditor({
-  bookmarkId,
-  allTags,
-  currentTagIds,
-  onSave,
-  onCancel,
-}: Props) {
+export function InlineTagEditor({ bookmarkId, allTags, currentTagIds, onSave, onCancel }: Props) {
   const [tagIds, setTagIds] = useState(currentTagIds);
   const [localNewTags, setLocalNewTags] = useState<Tag[]>([]);
   const [saving, setSaving] = useState(false);

--- a/src/app/(dashboard)/bookmarks/TagFilter.tsx
+++ b/src/app/(dashboard)/bookmarks/TagFilter.tsx
@@ -31,9 +31,7 @@ export function TagFilter({ tags, selectedTagIds, onChange }: Props) {
             type="button"
             onClick={() => toggle(tag.id)}
             className={`cursor-pointer rounded-full px-3 py-1 text-sm font-medium ${
-              active
-                ? "bg-zinc-900 text-white"
-                : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200"
+              active ? "bg-zinc-900 text-white" : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200"
             }`}
           >
             {tag.name}

--- a/src/app/(dashboard)/bookmarks/TagInput.tsx
+++ b/src/app/(dashboard)/bookmarks/TagInput.tsx
@@ -25,13 +25,10 @@ export function TagInput({ inputId, availableTags, selectedTagIds, onChange }: P
   const suggestions = trimmed
     ? availableTags.filter(
         (t) =>
-          t.name.toLowerCase().includes(trimmed.toLowerCase()) &&
-          !selectedTagIds.includes(t.id),
+          t.name.toLowerCase().includes(trimmed.toLowerCase()) && !selectedTagIds.includes(t.id),
       )
     : availableTags.filter((t) => !selectedTagIds.includes(t.id));
-  const exactMatch = availableTags.find(
-    (t) => t.name.toLowerCase() === trimmed.toLowerCase(),
-  );
+  const exactMatch = availableTags.find((t) => t.name.toLowerCase() === trimmed.toLowerCase());
   const canCreate = trimmed.length > 0 && trimmed.length <= 50 && !exactMatch;
 
   function removeTag(id: string) {

--- a/src/app/(dashboard)/bookmarks/UndoSnackbar.tsx
+++ b/src/app/(dashboard)/bookmarks/UndoSnackbar.tsx
@@ -8,7 +8,9 @@ type Props = {
 export function UndoSnackbar({ message, onUndo }: Props) {
   return (
     <div className="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-4 rounded-lg bg-zinc-900 px-5 py-3 text-sm text-white shadow-xl">
-      <span role="status" aria-live="polite" aria-atomic="true">{message}</span>
+      <span role="status" aria-live="polite" aria-atomic="true">
+        {message}
+      </span>
       <button
         type="button"
         onClick={onUndo}

--- a/src/app/(dashboard)/bookmarks/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/bookmarks/[id]/edit/page.tsx
@@ -5,8 +5,8 @@ export const metadata: Metadata = { title: "ブックマーク編集" };
 
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { updateBookmark } from "../../actions";
 import { BookmarkForm } from "../../BookmarkForm";
+import { updateBookmark } from "../../actions";
 
 export default async function EditBookmarkPage({ params }: { params: Promise<{ id: string }> }) {
   const session = await getSession();
@@ -28,7 +28,9 @@ export default async function EditBookmarkPage({ params }: { params: Promise<{ i
 
   return (
     <div>
-      <h2 className="mb-6 text-lg font-bold text-zinc-900">ブックマークを編集</h2>
+      <h2 className="mb-6 text-lg font-bold text-zinc-900">
+        ブックマークを編集
+      </h2>
       <BookmarkForm
         availableTags={tags}
         defaultValues={{

--- a/src/app/(dashboard)/bookmarks/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/bookmarks/[id]/edit/page.tsx
@@ -5,8 +5,8 @@ export const metadata: Metadata = { title: "ブックマーク編集" };
 
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { BookmarkForm } from "../../BookmarkForm";
 import { updateBookmark } from "../../actions";
+import { BookmarkForm } from "../../BookmarkForm";
 
 export default async function EditBookmarkPage({ params }: { params: Promise<{ id: string }> }) {
   const session = await getSession();
@@ -28,9 +28,7 @@ export default async function EditBookmarkPage({ params }: { params: Promise<{ i
 
   return (
     <div>
-      <h2 className="mb-6 text-lg font-bold text-zinc-900">
-        ブックマークを編集
-      </h2>
+      <h2 className="mb-6 text-lg font-bold text-zinc-900">ブックマークを編集</h2>
       <BookmarkForm
         availableTags={tags}
         defaultValues={{

--- a/src/app/(dashboard)/bookmarks/actions.test.ts
+++ b/src/app/(dashboard)/bookmarks/actions.test.ts
@@ -2,15 +2,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  bulkAddTags,
   createBookmark,
+  createTag,
   deleteBookmark,
   deleteBookmarks,
+  deleteTag,
+  reorderBookmarks,
   updateBookmark,
   updateBookmarkTags,
-  reorderBookmarks,
-  createTag,
-  deleteTag,
-  bulkAddTags,
 } from "./actions";
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));

--- a/src/app/(dashboard)/bookmarks/actions.ts
+++ b/src/app/(dashboard)/bookmarks/actions.ts
@@ -6,13 +6,13 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth";
 import {
   type BookmarkData,
+  bulkAddTags as libBulkAddTags,
   createBookmark as libCreateBookmark,
-  updateBookmark as libUpdateBookmark,
-  updateBookmarkTags as libUpdateBookmarkTags,
-  reorderBookmarks as libReorderBookmarks,
   deleteBookmark as libDeleteBookmark,
   deleteBookmarks as libDeleteBookmarks,
-  bulkAddTags as libBulkAddTags,
+  reorderBookmarks as libReorderBookmarks,
+  updateBookmark as libUpdateBookmark,
+  updateBookmarkTags as libUpdateBookmarkTags,
 } from "@/lib/bookmarks";
 import { createTag as libCreateTag, deleteTag as libDeleteTag } from "@/lib/tags";
 

--- a/src/app/(dashboard)/bookmarks/fetchOgp.test.ts
+++ b/src/app/(dashboard)/bookmarks/fetchOgp.test.ts
@@ -179,9 +179,7 @@ describe("fetchOgp", () => {
   });
 
   it("og:title も <title> タグもない場合 title は undefined で返す", async () => {
-    mockFetch.mockResolvedValue(
-      makeHtmlResponse(`<html><head></head><body></body></html>`),
-    );
+    mockFetch.mockResolvedValue(makeHtmlResponse(`<html><head></head><body></body></html>`));
 
     const result = await fetchOgp("https://example.com");
 

--- a/src/app/(dashboard)/bookmarks/new/page.tsx
+++ b/src/app/(dashboard)/bookmarks/new/page.tsx
@@ -5,8 +5,8 @@ export const metadata: Metadata = { title: "ブックマーク追加" };
 
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { createBookmark } from "../actions";
 import { BookmarkForm } from "../BookmarkForm";
+import { createBookmark } from "../actions";
 
 export default async function NewBookmarkPage() {
   const session = await getSession();
@@ -20,7 +20,9 @@ export default async function NewBookmarkPage() {
 
   return (
     <div>
-      <h2 className="mb-6 text-lg font-bold text-zinc-900">ブックマークを追加</h2>
+      <h2 className="mb-6 text-lg font-bold text-zinc-900">
+        ブックマークを追加
+      </h2>
       <BookmarkForm availableTags={tags} action={createBookmark} />
     </div>
   );

--- a/src/app/(dashboard)/bookmarks/new/page.tsx
+++ b/src/app/(dashboard)/bookmarks/new/page.tsx
@@ -5,8 +5,8 @@ export const metadata: Metadata = { title: "ブックマーク追加" };
 
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { BookmarkForm } from "../BookmarkForm";
 import { createBookmark } from "../actions";
+import { BookmarkForm } from "../BookmarkForm";
 
 export default async function NewBookmarkPage() {
   const session = await getSession();
@@ -20,9 +20,7 @@ export default async function NewBookmarkPage() {
 
   return (
     <div>
-      <h2 className="mb-6 text-lg font-bold text-zinc-900">
-        ブックマークを追加
-      </h2>
+      <h2 className="mb-6 text-lg font-bold text-zinc-900">ブックマークを追加</h2>
       <BookmarkForm availableTags={tags} action={createBookmark} />
     </div>
   );

--- a/src/app/(dashboard)/bookmarks/tags/TagsClient.tsx
+++ b/src/app/(dashboard)/bookmarks/tags/TagsClient.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
 import { flushSync } from "react-dom";
-import { useRouter } from "next/navigation";
 
 import { createTag, deleteTag } from "../actions";
 
@@ -36,9 +36,7 @@ export function TagsClient({ initialTags }: { initialTags: Tag[] }) {
       }
       const newTag = result.tag;
       setTags((prev) =>
-        [...prev, { ...newTag, bookmarkCount: 0 }].sort((a, b) =>
-          a.name.localeCompare(b.name),
-        ),
+        [...prev, { ...newTag, bookmarkCount: 0 }].sort((a, b) => a.name.localeCompare(b.name)),
       );
       setInputValue("");
     } finally {
@@ -91,9 +89,7 @@ export function TagsClient({ initialTags }: { initialTags: Tag[] }) {
         </button>
       </form>
 
-      {error && (
-        <p className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-600">{error}</p>
-      )}
+      {error && <p className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-600">{error}</p>}
 
       {tags.length === 0 ? (
         <div className="rounded-lg border border-dashed border-zinc-300 py-16 text-center text-sm text-zinc-500">

--- a/src/app/(dashboard)/bookmarks/tags/page.tsx
+++ b/src/app/(dashboard)/bookmarks/tags/page.tsx
@@ -18,10 +18,7 @@ export default async function TagsPage() {
     <div>
       <div className="mb-6 flex items-center justify-between">
         <h2 className="text-lg font-bold text-zinc-900">タグ管理</h2>
-        <Link
-          href="/bookmarks"
-          className="text-sm text-zinc-500 hover:text-zinc-700"
-        >
+        <Link href="/bookmarks" className="text-sm text-zinc-500 hover:text-zinc-700">
           ← ブックマーク一覧へ
         </Link>
       </div>

--- a/src/app/(dashboard)/bookmarks/tags/page.tsx
+++ b/src/app/(dashboard)/bookmarks/tags/page.tsx
@@ -18,7 +18,10 @@ export default async function TagsPage() {
     <div>
       <div className="mb-6 flex items-center justify-between">
         <h2 className="text-lg font-bold text-zinc-900">タグ管理</h2>
-        <Link href="/bookmarks" className="text-sm text-zinc-500 hover:text-zinc-700">
+        <Link
+          href="/bookmarks"
+          className="text-sm text-zinc-500 hover:text-zinc-700"
+        >
           ← ブックマーク一覧へ
         </Link>
       </div>

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,7 +1,6 @@
 import { redirect } from "next/navigation";
-
-import { getSession } from "@/lib/auth";
 import { Header } from "@/components/Header";
+import { getSession } from "@/lib/auth";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const session = await getSession();

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
-import { Header } from "@/components/Header";
+
 import { getSession } from "@/lib/auth";
+import { Header } from "@/components/Header";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const session = await getSession();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,9 @@ export default function RootLayout({
   return (
     <ClerkProvider>
       <html lang="ja">
-        <body className={`${mPlus1Code.variable} font-mplus1code antialiased`}>{children}</body>
+        <body className={`${mPlus1Code.variable} font-mplus1code antialiased`}>
+          {children}
+        </body>
       </html>
     </ClerkProvider>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,9 +23,7 @@ export default function RootLayout({
   return (
     <ClerkProvider>
       <html lang="ja">
-        <body className={`${mPlus1Code.variable} font-mplus1code antialiased`}>
-          {children}
-        </body>
+        <body className={`${mPlus1Code.variable} font-mplus1code antialiased`}>{children}</body>
       </html>
     </ClerkProvider>
   );

--- a/src/lib/bookmarks.test.ts
+++ b/src/lib/bookmarks.test.ts
@@ -2,14 +2,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
-  getBookmarks,
+  bulkAddTags,
   createBookmark,
-  updateBookmark,
-  updateBookmarkTags,
-  reorderBookmarks,
   deleteBookmark,
   deleteBookmarks,
-  bulkAddTags,
+  getBookmarks,
+  reorderBookmarks,
+  updateBookmark,
+  updateBookmarkTags,
 } from "./bookmarks";
 
 vi.mock("@/lib/prisma", () => ({

--- a/src/lib/bookmarks.ts
+++ b/src/lib/bookmarks.ts
@@ -62,9 +62,7 @@ export async function createBookmark(
       memo: data.memo || null,
       ogImage: data.ogImage ?? null,
       sortOrder,
-      ...(validTagIds.length
-        ? { tags: { create: validTagIds.map((tagId) => ({ tagId })) } }
-        : {}),
+      ...(validTagIds.length ? { tags: { create: validTagIds.map((tagId) => ({ tagId })) } } : {}),
     },
   });
 
@@ -80,17 +78,16 @@ export async function updateBookmark(
   if (!bookmark) return { error: "ブックマークが見つかりません" };
   if (bookmark.userId !== userId) return { error: "権限がありません" };
 
-  const validTagIds =
-    data.tagIds?.length
-      ? (
-          await prisma.tag.findMany({
-            where: { id: { in: data.tagIds }, userId },
-            select: { id: true },
-          })
-        ).map((t) => t.id)
-      : data.tagIds !== undefined
-        ? []
-        : undefined;
+  const validTagIds = data.tagIds?.length
+    ? (
+        await prisma.tag.findMany({
+          where: { id: { in: data.tagIds }, userId },
+          select: { id: true },
+        })
+      ).map((t) => t.id)
+    : data.tagIds !== undefined
+      ? []
+      : undefined;
 
   await prisma.bookmark.update({
     where: { id },
@@ -103,9 +100,7 @@ export async function updateBookmark(
         ? {
             tags: {
               deleteMany: {},
-              ...(validTagIds.length
-                ? { create: validTagIds.map((tagId) => ({ tagId })) }
-                : {}),
+              ...(validTagIds.length ? { create: validTagIds.map((tagId) => ({ tagId })) } : {}),
             },
           }
         : {}),
@@ -138,9 +133,7 @@ export async function updateBookmarkTags(
     data: {
       tags: {
         deleteMany: {},
-        ...(validTagIds.length
-          ? { create: validTagIds.map((tagId) => ({ tagId })) }
-          : {}),
+        ...(validTagIds.length ? { create: validTagIds.map((tagId) => ({ tagId })) } : {}),
       },
     },
   });
@@ -148,28 +141,20 @@ export async function updateBookmarkTags(
   return {};
 }
 
-export async function reorderBookmarks(
-  userId: string,
-  ids: string[],
-): Promise<{ error?: string }> {
+export async function reorderBookmarks(userId: string, ids: string[]): Promise<{ error?: string }> {
   const owned = await prisma.bookmark.count({
     where: { id: { in: ids }, userId },
   });
   if (owned !== ids.length) return { error: "権限がありません" };
 
   await prisma.$transaction(
-    ids.map((id, index) =>
-      prisma.bookmark.update({ where: { id }, data: { sortOrder: index } }),
-    ),
+    ids.map((id, index) => prisma.bookmark.update({ where: { id }, data: { sortOrder: index } })),
   );
 
   return {};
 }
 
-export async function deleteBookmark(
-  userId: string,
-  id: string,
-): Promise<{ error?: string }> {
+export async function deleteBookmark(userId: string, id: string): Promise<{ error?: string }> {
   const bookmark = await prisma.bookmark.findUnique({ where: { id } });
   if (!bookmark) return { error: "ブックマークが見つかりません" };
   if (bookmark.userId !== userId) return { error: "権限がありません" };
@@ -179,10 +164,7 @@ export async function deleteBookmark(
   return {};
 }
 
-export async function deleteBookmarks(
-  userId: string,
-  ids: string[],
-): Promise<{ error?: string }> {
+export async function deleteBookmarks(userId: string, ids: string[]): Promise<{ error?: string }> {
   await prisma.bookmark.deleteMany({
     where: { id: { in: ids }, userId },
   });

--- a/src/lib/tags.test.ts
+++ b/src/lib/tags.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment node
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Prisma } from "@prisma/client";
 
-import { getTags, getTagsWithCount, createTag, deleteTag } from "./tags";
+import { Prisma } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTag, deleteTag, getTags, getTagsWithCount } from "./tags";
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
@@ -36,9 +37,7 @@ describe("getTags", () => {
 
     const result = await getTags(userId);
 
-    expect(mockTagFindMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { userId } }),
-    );
+    expect(mockTagFindMany).toHaveBeenCalledWith(expect.objectContaining({ where: { userId } }));
     expect(result).toEqual([tag]);
   });
 });
@@ -93,9 +92,7 @@ describe("createTag", () => {
   });
 
   it("P2002 レース条件の場合は { conflict: true, tag } を返す", async () => {
-    mockTagFindUnique
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(tag as never);
+    mockTagFindUnique.mockResolvedValueOnce(null).mockResolvedValueOnce(tag as never);
     const p2002 = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
       code: "P2002",
       clientVersion: "7.5.0",

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -53,10 +53,7 @@ export async function createTag(
   }
 }
 
-export async function deleteTag(
-  userId: string,
-  id: string,
-): Promise<{ error?: string }> {
+export async function deleteTag(userId: string, id: string): Promise<{ error?: string }> {
   const tag = await prisma.tag.findUnique({ where: { id } });
   if (!tag) return { error: "タグが見つかりません" };
   if (tag.userId !== userId) return { error: "権限がありません" };


### PR DESCRIPTION
## Summary
- biome の `check --write` を実行し、自動修正された 5 ファイルのフォーマットを適用
- インポート順の整列（`organizeImports`）
- 短くまとめられる JSX の1行化

## 変更ファイル
- `src/app/layout.tsx`
- `src/app/(dashboard)/layout.tsx`
- `src/app/(dashboard)/bookmarks/new/page.tsx`
- `src/app/(dashboard)/bookmarks/[id]/edit/page.tsx`
- `src/app/(dashboard)/bookmarks/tags/page.tsx`

## Test plan
- [ ] 機能変更なし（フォーマットのみ）
- [ ] biome check がエラーなしで通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)