### PR TITLE
[T80] アプリアイコンの viewBox 統一・ヘッダーアイコンコンポーネント化

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,28 +1,5 @@
 import { LogoutButton } from "@/app/(dashboard)/LogoutButton";
-
-function LinkHubIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      width="20"
-      height="20"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-      <line x1="12" y1="5" x2="12" y2="2" />
-      <line x1="12" y1="22" x2="12" y2="19" />
-      <line x1="5" y1="12" x2="2" y2="12" />
-      <line x1="22" y1="12" x2="19" y2="12" />
-    </svg>
-  );
-}
+import { AppIcon } from "@/components/icons/AppIcon";
 
 type Props = {
   email: string;
@@ -33,7 +10,7 @@ export function Header({ email }: Props) {
     <header className="sticky top-0 z-10 border-b border-zinc-200 bg-white">
       <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
         <div className="flex items-center gap-2 text-zinc-900">
-          <LinkHubIcon />
+          <AppIcon />
           <span className="text-lg font-bold">Link Hub</span>
         </div>
         <div className="flex items-center gap-4">

--- a/src/components/icons/AppIcon.tsx
+++ b/src/components/icons/AppIcon.tsx
@@ -1,0 +1,27 @@
+type Props = {
+  size?: number;
+};
+
+export function AppIcon({ size = 20 }: Props) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+      <line x1="12" y1="5" x2="12" y2="2" />
+      <line x1="12" y1="22" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="2" y2="12" />
+      <line x1="22" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- `src/components/icons/AppIcon.tsx` を新規作成し、インライン SVG をコンポーネント化（`size` prop 対応）
- `src/components/Header.tsx` の `LinkHubIcon` 関数を `AppIcon` コンポーネントに置き換え
- `public/favicon.svg` と `AppIcon` の SVG パスが一致していることを確認済み

Closes #188

## Test plan
- [ ] ブラウザタブの favicon が正常に表示される
- [ ] ヘッダー左のアイコンが 20×20px で表示される
- [ ] 各ページ遷移でヘッダー表示が正常
- [ ] スティッキーヘッダーが動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)