### PR TITLE
[T81] ブックマーク一覧のデザイン改善（カード化・カラータグ・ホバーエフェクト）

### DIFF
--- a/src/app/(dashboard)/bookmarks/BookmarkList.tsx
+++ b/src/app/(dashboard)/bookmarks/BookmarkList.tsx
@@ -131,7 +131,9 @@ function SortableItem({
 
   const style = {
     transform: CSS.Transform.toString(transform),
-    transition,
+    transition: [transition, "background-color 150ms ease-in-out", "border-color 150ms ease-in-out"]
+      .filter(Boolean)
+      .join(", "),
     opacity: isDragging ? 0.5 : 1,
   };
 
@@ -139,7 +141,7 @@ function SortableItem({
     <li
       ref={setNodeRef}
       style={style}
-      className="flex items-center gap-3 rounded-lg border border-zinc-200 bg-white px-4 py-3 transition-all duration-150 ease-in-out hover:border-zinc-400 hover:bg-zinc-50"
+      className="flex items-center gap-3 rounded-lg border border-zinc-200 bg-white px-4 py-3 hover:border-zinc-400 hover:bg-zinc-50"
     >
       {!isDndDisabled && (
         <button

--- a/src/app/(dashboard)/bookmarks/BookmarkList.tsx
+++ b/src/app/(dashboard)/bookmarks/BookmarkList.tsx
@@ -19,6 +19,7 @@ import { CSS } from "@dnd-kit/utilities";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { getTagColor } from "@/lib/tag-colors";
 import { bulkAddTags, deleteBookmark, deleteBookmarks, reorderBookmarks } from "./actions";
 import { BulkTagPanel } from "./BulkTagPanel";
 import { InlineTagEditor } from "./InlineTagEditor";
@@ -85,7 +86,7 @@ function PlainItem({
   onEditTagsCancel,
 }: ItemProps) {
   return (
-    <li className="flex items-center gap-3 px-4 py-3 bg-white">
+    <li className="flex items-center gap-3 rounded-lg border border-zinc-200 bg-white px-4 py-3 transition-all duration-150 ease-in-out hover:border-zinc-400 hover:bg-zinc-50">
       {isDndDisabled ? null : (
         <span className="shrink-0 text-zinc-400">
           <DragHandleIcon />
@@ -135,7 +136,11 @@ function SortableItem({
   };
 
   return (
-    <li ref={setNodeRef} style={style} className="flex items-center gap-3 px-4 py-3 bg-white">
+    <li
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-3 rounded-lg border border-zinc-200 bg-white px-4 py-3 transition-all duration-150 ease-in-out hover:border-zinc-400 hover:bg-zinc-50"
+    >
       {!isDndDisabled && (
         <button
           type="button"
@@ -191,7 +196,7 @@ function ItemContent({
           href={bm.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="block truncate text-sm font-medium text-zinc-900 hover:underline"
+          className="block truncate text-sm font-medium text-zinc-900 transition-colors duration-150 hover:text-purple-700 hover:underline"
         >
           {bm.title}
         </a>
@@ -200,10 +205,11 @@ function ItemContent({
         <div className="mt-1 flex flex-wrap items-center gap-1">
           {bm.tags.map((bt) => {
             const tagName = allTags.find((t) => t.id === bt.tagId)?.name ?? bt.tag.name;
+            const color = getTagColor(tagName);
             return (
               <span
                 key={bt.tagId}
-                className="inline-flex rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-500"
+                className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${color.bg} ${color.text}`}
               >
                 {tagName}
               </span>
@@ -572,7 +578,7 @@ export function BookmarkList({
             items={filteredItems.map((b) => b.id)}
             strategy={verticalListSortingStrategy}
           >
-            <ul className="divide-y divide-zinc-100 rounded-lg border border-zinc-200">
+            <ul className="flex flex-col gap-3">
               {filteredItems.map((bm) => (
                 <SortableItem key={bm.id} {...itemProps(bm)} />
               ))}

--- a/src/app/(dashboard)/bookmarks/BulkTagPanel.tsx
+++ b/src/app/(dashboard)/bookmarks/BulkTagPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { getTagColor } from "@/lib/tag-colors";
 
 import type { TagFilterItem } from "./TagFilter";
 
@@ -28,13 +29,16 @@ export function BulkTagPanel({ allTags, saving, error, onSave, onCancel }: Props
         <div className="mb-3 flex flex-wrap gap-2">
           {allTags.map((tag) => {
             const active = selectedTagIds.includes(tag.id);
+            const color = getTagColor(tag.name);
             return (
               <button
                 key={tag.id}
                 type="button"
                 onClick={() => toggle(tag.id)}
                 className={`cursor-pointer rounded-full px-3 py-1 text-sm font-medium ${
-                  active ? "bg-zinc-900 text-white" : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200"
+                  active
+                    ? `${color.activeBg} text-white`
+                    : `${color.bg} ${color.text} hover:opacity-80`
                 }`}
               >
                 {tag.name}

--- a/src/app/(dashboard)/bookmarks/TagFilter.tsx
+++ b/src/app/(dashboard)/bookmarks/TagFilter.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { getTagColor } from "@/lib/tag-colors";
+
 export type TagFilterItem = { id: string; name: string };
 
 const UNTAGGED_ID = "__untagged__";
@@ -25,13 +27,14 @@ export function TagFilter({ tags, selectedTagIds, onChange }: Props) {
     <div className="mb-4 flex flex-wrap gap-2">
       {tags.map((tag) => {
         const active = selectedTagIds.includes(tag.id);
+        const color = getTagColor(tag.name);
         return (
           <button
             key={tag.id}
             type="button"
             onClick={() => toggle(tag.id)}
             className={`cursor-pointer rounded-full px-3 py-1 text-sm font-medium ${
-              active ? "bg-zinc-900 text-white" : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200"
+              active ? `${color.activeBg} text-white` : `${color.bg} ${color.text} hover:opacity-80`
             }`}
           >
             {tag.name}

--- a/src/lib/tag-colors.test.ts
+++ b/src/lib/tag-colors.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { getTagColor } from "./tag-colors";
+
+describe("getTagColor", () => {
+  it("同名タグで常に同じ色を返す", () => {
+    const color1 = getTagColor("開発");
+    const color2 = getTagColor("開発");
+    expect(color1).toEqual(color2);
+  });
+
+  it("パレット範囲内の色を返す", () => {
+    const tags = [
+      "開発",
+      "CSS",
+      "ツール",
+      "デザイン",
+      "API",
+      "DB",
+      "",
+      "あ",
+      "very-long-tag-name-test",
+    ];
+    for (const tag of tags) {
+      const color = getTagColor(tag);
+      expect(color).toHaveProperty("bg");
+      expect(color).toHaveProperty("text");
+      expect(color).toHaveProperty("activeBg");
+      expect(color.bg).toMatch(/^bg-\w+-50$/);
+      expect(color.text).toMatch(/^text-\w+-800$/);
+      expect(color.activeBg).toMatch(/^bg-\w+-600$/);
+    }
+  });
+
+  it("異なるタグ名で異なる色が返るケースがある", () => {
+    const colors = new Set(
+      ["開発", "CSS", "ツール", "デザイン", "API", "DB"].map((t) => getTagColor(t).bg),
+    );
+    expect(colors.size).toBeGreaterThan(1);
+  });
+});

--- a/src/lib/tag-colors.ts
+++ b/src/lib/tag-colors.ts
@@ -1,0 +1,22 @@
+const TAG_COLOR_PALETTE = [
+  { bg: "bg-blue-50", text: "text-blue-800", activeBg: "bg-blue-600" },
+  { bg: "bg-purple-50", text: "text-purple-800", activeBg: "bg-purple-600" },
+  { bg: "bg-teal-50", text: "text-teal-800", activeBg: "bg-teal-600" },
+  { bg: "bg-orange-50", text: "text-orange-800", activeBg: "bg-orange-600" },
+  { bg: "bg-amber-50", text: "text-amber-800", activeBg: "bg-amber-600" },
+  { bg: "bg-pink-50", text: "text-pink-800", activeBg: "bg-pink-600" },
+] as const;
+
+function hashString(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash << 5) - hash + str.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+export function getTagColor(tagName: string) {
+  const index = hashString(tagName) % TAG_COLOR_PALETTE.length;
+  return TAG_COLOR_PALETTE[index];
+}


### PR DESCRIPTION
## Summary
- ブックマーク一覧を `divide-y` リスト → 独立カードデザイン（`gap-3` + `rounded-lg border`）に変更
- タグチップにタグ名ハッシュベースのカラーバリエーション（6色パレット）を適用
- カード・タイトルにホバーエフェクト（`transition-all duration-150`）を追加
- TagFilter・BulkTagPanel のタグチップにも同じカラーを統一適用

Closes #190

## Test plan
- [ ] カードデザインで各ブックマークが独立表示される
- [ ] ホバー時に背景色・ボーダー・タイトル色が滑らかに変化する
- [ ] 同名タグは常に同じ色で表示される
- [ ] タグフィルター・一括タグパネルでもカラーが適用される
- [ ] ドラッグ&ドロップ・検索が正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)