### PR TITLE
[T85] BookmarkList.tsx のリファクタリング

### DIFF
--- a/src/app/(dashboard)/bookmarks/BookmarkItemContent.tsx
+++ b/src/app/(dashboard)/bookmarks/BookmarkItemContent.tsx
@@ -1,0 +1,52 @@
+import type { Bookmark } from "./types";
+
+export function BookmarkItemContent({
+  bm,
+  onEdit,
+  onDelete,
+}: {
+  bm: Bookmark;
+  onEdit: (bm: Bookmark) => void;
+  onDelete: (bm: Bookmark) => void;
+}) {
+  return (
+    <>
+      <div className="min-w-0 flex-1">
+        <a
+          href={bm.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block truncate text-sm font-medium text-zinc-900 transition-colors duration-150 hover:text-purple-700 hover:underline"
+        >
+          {bm.title}
+        </a>
+        <p className="truncate text-xs text-zinc-400">{bm.url}</p>
+        {bm.memo && <p className="truncate text-sm text-zinc-600">{bm.memo}</p>}
+      </div>
+      {bm.ogImage && (
+        <img
+          src={bm.ogImage}
+          alt=""
+          className="h-20 w-36 shrink-0 rounded object-contain"
+          referrerPolicy="no-referrer"
+        />
+      )}
+      <div className="flex shrink-0 gap-2">
+        <button
+          type="button"
+          onClick={() => onEdit(bm)}
+          className="cursor-pointer rounded bg-zinc-100 px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-200"
+        >
+          編集
+        </button>
+        <button
+          type="button"
+          onClick={() => onDelete(bm)}
+          className="cursor-pointer rounded border border-red-300 px-3 py-1 text-xs font-medium text-red-600 hover:bg-red-50"
+        >
+          削除
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/app/(dashboard)/bookmarks/BookmarkList.tsx
+++ b/src/app/(dashboard)/bookmarks/BookmarkList.tsx
@@ -1,25 +1,7 @@
 "use client";
 
-import {
-  type CollisionDetection,
-  closestCenter,
-  DndContext,
-  type DragEndEvent,
-  type DragOverEvent,
-  DragOverlay,
-  type DragStartEvent,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
+import { DndContext, DragOverlay } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { BookmarkAddModal } from "@/components/BookmarkAddModal";
@@ -32,262 +14,17 @@ import {
   deleteBookmark,
   deleteBookmarks,
   deleteTag,
-  moveBookmark,
-  reorderBookmarks,
-  reorderTags,
   updateBookmark,
 } from "./actions";
+import { BookmarkItemContent } from "./BookmarkItemContent";
+import { CategoryGroup } from "./CategoryGroup";
+import { DragHandleIcon } from "./DragHandleIcon";
+import type { Bookmark, PendingDelete, TagItem, TagWithCount } from "./types";
+import { UNCATEGORIZED_KEY } from "./types";
 import { UndoSnackbar } from "./UndoSnackbar";
+import { useDragAndDrop } from "./useDragAndDrop";
 
-const UNCATEGORIZED_KEY = "__uncategorized__";
 const UNDO_TIMEOUT_MS = 5000;
-
-type Bookmark = {
-  id: string;
-  url: string;
-  title: string;
-  memo: string | null;
-  ogImage: string | null;
-  sortOrder: number;
-  tag: { id: string; name: string } | null;
-  tagId: string | null;
-};
-
-type TagItem = { id: string; name: string };
-type TagWithCount = { id: string; name: string; bookmarkCount: number };
-
-type PendingDelete = {
-  bookmarks: Bookmark[];
-  timerId: ReturnType<typeof setTimeout>;
-};
-
-function DragHandleIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      aria-hidden="true"
-    >
-      <path d="M8 6a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM8 12a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM8 18a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM20 6a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM20 12a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM20 18a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z" />
-    </svg>
-  );
-}
-
-function SortableBookmarkItem({
-  bm,
-  isSearching,
-  onEdit,
-  onDelete,
-}: {
-  bm: Bookmark;
-  isSearching: boolean;
-  onEdit: (bm: Bookmark) => void;
-  onDelete: (bm: Bookmark) => void;
-}) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: bm.id,
-    disabled: isSearching,
-    data: { type: "bookmark", tagId: bm.tagId },
-  });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition: transition || undefined,
-    opacity: isDragging ? 0.4 : 1,
-  };
-
-  return (
-    <li
-      ref={setNodeRef}
-      style={style}
-      className="flex items-center gap-3 rounded-lg border border-zinc-200 bg-white px-4 py-3 hover:border-zinc-400 hover:bg-zinc-50"
-    >
-      {!isSearching && (
-        <button
-          type="button"
-          {...attributes}
-          {...listeners}
-          className="shrink-0 cursor-grab text-zinc-400 hover:text-zinc-600 active:cursor-grabbing"
-          aria-label="ドラッグして並び替え"
-        >
-          <DragHandleIcon />
-        </button>
-      )}
-      <BookmarkItemContent bm={bm} onEdit={onEdit} onDelete={onDelete} />
-    </li>
-  );
-}
-
-function BookmarkItemContent({
-  bm,
-  onEdit,
-  onDelete,
-}: {
-  bm: Bookmark;
-  onEdit: (bm: Bookmark) => void;
-  onDelete: (bm: Bookmark) => void;
-}) {
-  return (
-    <>
-      <div className="min-w-0 flex-1">
-        <a
-          href={bm.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="block truncate text-sm font-medium text-zinc-900 transition-colors duration-150 hover:text-purple-700 hover:underline"
-        >
-          {bm.title}
-        </a>
-        <p className="truncate text-xs text-zinc-400">{bm.url}</p>
-        {bm.memo && <p className="truncate text-sm text-zinc-600">{bm.memo}</p>}
-      </div>
-      {bm.ogImage && (
-        <img
-          src={bm.ogImage}
-          alt=""
-          className="h-20 w-36 shrink-0 rounded object-contain"
-          referrerPolicy="no-referrer"
-        />
-      )}
-      <div className="flex shrink-0 gap-2">
-        <button
-          type="button"
-          onClick={() => onEdit(bm)}
-          className="cursor-pointer rounded bg-zinc-100 px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-200"
-        >
-          編集
-        </button>
-        <button
-          type="button"
-          onClick={() => onDelete(bm)}
-          className="cursor-pointer rounded border border-red-300 px-3 py-1 text-xs font-medium text-red-600 hover:bg-red-50"
-        >
-          削除
-        </button>
-      </div>
-    </>
-  );
-}
-
-function CategoryDropZone({ categoryKey }: { categoryKey: string }) {
-  const { setNodeRef, isOver } = useSortable({
-    id: `drop-zone-${categoryKey}`,
-    data: { type: "drop-zone", tagId: categoryKey === UNCATEGORIZED_KEY ? null : categoryKey },
-  });
-
-  if (!isOver) return <div ref={setNodeRef} className="h-1" />;
-
-  return (
-    <div
-      ref={setNodeRef}
-      className="rounded-md border-2 border-dashed border-blue-400 bg-blue-50 py-4 text-center text-xs text-blue-500"
-    >
-      ここにドロップ
-    </div>
-  );
-}
-
-function CategoryGroup({
-  categoryKey,
-  tag,
-  bookmarks,
-  isSearching,
-  onEdit,
-  onDelete,
-}: {
-  categoryKey: string;
-  tag: TagItem | null;
-  bookmarks: Bookmark[];
-  isSearching: boolean;
-  onEdit: (bm: Bookmark) => void;
-  onDelete: (bm: Bookmark) => void;
-}) {
-  const [collapsed, setCollapsed] = useState(false);
-  const color = tag ? getTagColor(tag.name) : null;
-  const isSortable = tag !== null;
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: `category-${categoryKey}`,
-    disabled: !isSortable,
-    data: { type: "category" },
-  });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition: transition || undefined,
-    opacity: isDragging ? 0.4 : 1,
-  };
-
-  return (
-    <div ref={setNodeRef} style={style} className="mb-6">
-      <div className="mb-2 flex w-full items-center gap-2 border-b border-zinc-200 pb-1.5">
-        {isSortable && (
-          <button
-            type="button"
-            {...attributes}
-            {...listeners}
-            className="shrink-0 cursor-grab text-zinc-400 hover:text-zinc-600 active:cursor-grabbing"
-            aria-label="ドラッグしてカテゴリを並び替え"
-          >
-            <DragHandleIcon />
-          </button>
-        )}
-        <button
-          type="button"
-          onClick={() => setCollapsed((prev) => !prev)}
-          className="flex flex-1 cursor-pointer items-center gap-2"
-        >
-          <span
-            className={`inline-block h-2.5 w-2.5 rounded-full ${color ? color.activeBg : "bg-zinc-400"}`}
-          />
-          <span className={`text-sm font-medium ${tag ? "text-zinc-900" : "text-zinc-500"}`}>
-            {tag ? tag.name : "未分類"}
-          </span>
-          <span className="text-xs text-zinc-400">{bookmarks.length}</span>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-            className={`ml-auto text-zinc-400 transition-transform ${collapsed ? "-rotate-90" : ""}`}
-          >
-            <polyline points="6 9 12 15 18 9" />
-          </svg>
-        </button>
-      </div>
-
-      {!collapsed && (
-        <div className="pl-5">
-          <SortableContext
-            items={[...bookmarks.map((b) => b.id), `drop-zone-${categoryKey}`]}
-            strategy={verticalListSortingStrategy}
-          >
-            <ul className="flex flex-col gap-2">
-              {bookmarks.map((bm) => (
-                <SortableBookmarkItem
-                  key={bm.id}
-                  bm={bm}
-                  isSearching={isSearching}
-                  onEdit={onEdit}
-                  onDelete={onDelete}
-                />
-              ))}
-              <CategoryDropZone categoryKey={categoryKey} />
-            </ul>
-          </SortableContext>
-        </div>
-      )}
-    </div>
-  );
-}
 
 export function BookmarkList({
   bookmarks: initial,
@@ -309,7 +46,6 @@ export function BookmarkList({
   const [editingBookmarkId, setEditingBookmarkId] = useState<string | null>(null);
   const [pending, setPending] = useState<PendingDelete | null>(null);
   const pendingRef = useRef<PendingDelete | null>(null);
-  const [activeId, setActiveId] = useState<string | null>(null);
 
   useEffect(() => {
     setMounted(true);
@@ -417,167 +153,14 @@ export function BookmarkList({
     setItems((prev) => [...prev, ...bookmarks]);
   }, []);
 
-  const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-  );
-
-  const collisionDetection: CollisionDetection = useCallback((args) => {
-    const activeData = args.active.data.current as { type: string } | undefined;
-    if (activeData?.type === "category") {
-      const categoryContainers = args.droppableContainers.filter(
-        (c) => (c.data.current as { type: string } | undefined)?.type === "category",
-      );
-      return closestCenter({ ...args, droppableContainers: categoryContainers });
-    }
-    return closestCenter(args);
-  }, []);
-
-  const itemsRef = useRef<Bookmark[]>(initial);
-  useEffect(() => {
-    itemsRef.current = items;
-  }, [items]);
-
-  const allTagsRef = useRef<TagItem[]>(allTags);
-  useEffect(() => {
-    allTagsRef.current = allTagsState;
-  }, [allTagsState]);
-
-  const handleDragStart = useCallback((event: DragStartEvent) => {
-    setActiveId(event.active.id as string);
-  }, []);
-
-  const handleDragOver = useCallback(
-    (event: DragOverEvent) => {
-      const { active, over } = event;
-      if (!over) return;
-
-      const activeData = active.data.current as { type: string; tagId: string | null } | undefined;
-      const overData = over.data.current as { type: string; tagId: string | null } | undefined;
-      if (!activeData || activeData.type !== "bookmark") return;
-
-      let targetTagId: string | null | undefined;
-
-      if (overData?.type === "drop-zone") {
-        targetTagId = overData.tagId;
-      } else if (overData?.type === "bookmark") {
-        targetTagId = overData.tagId;
-      } else {
-        return;
-      }
-
-      if (targetTagId === undefined) return;
-      if (activeData.tagId === targetTagId) return;
-
-      const draggedId = active.id as string;
-      const newTag = targetTagId ? (allTagsState.find((t) => t.id === targetTagId) ?? null) : null;
-
-      setItems((prev) =>
-        prev.map((bm) =>
-          bm.id === draggedId ? { ...bm, tagId: targetTagId ?? null, tag: newTag } : bm,
-        ),
-      );
-    },
-    [allTagsState],
-  );
-
-  const handleDragEnd = useCallback(async (event: DragEndEvent) => {
-    setActiveId(null);
-    const { active, over } = event;
-    if (!over) return;
-
-    const activeData = active.data.current as { type: string } | undefined;
-    if (activeData?.type === "category") {
-      const activeKey = (active.id as string).replace("category-", "");
-      const overKey = (over.id as string).replace("category-", "");
-      if (activeKey === overKey) return;
-
-      const oldTags = allTagsRef.current;
-      const oldIndex = oldTags.findIndex((t) => t.id === activeKey);
-      const overIndex = oldTags.findIndex((t) => t.id === overKey);
-      if (oldIndex === -1 || overIndex === -1) return;
-
-      const newTags = [...oldTags];
-      const [moved] = newTags.splice(oldIndex, 1);
-      newTags.splice(overIndex, 0, moved);
-      setAllTagsState(newTags);
-
-      try {
-        const result = await reorderTags(
-          newTags.map((t) => t.id),
-          { skipRevalidate: true },
-        );
-        if (result.error) throw new Error(result.error);
-      } catch {
-        setAllTagsState(oldTags);
-      }
-      return;
-    }
-
-    const draggedId = active.id as string;
-    const bm = itemsRef.current.find((b) => b.id === draggedId);
-    if (!bm) return;
-
-    const overData = over.data.current as { type: string; tagId: string | null } | undefined;
-
-    let targetTagId: string | null;
-    if (overData?.type === "drop-zone") {
-      targetTagId = overData.tagId;
-    } else if (overData?.type === "bookmark") {
-      targetTagId = overData.tagId;
-    } else {
-      targetTagId = bm.tagId;
-    }
-
-    const currentItems = itemsRef.current;
-    const categoryItems = currentItems
-      .filter((b) => b.tagId === targetTagId)
-      .toSorted((a, b) => a.sortOrder - b.sortOrder);
-    const overId = over.id as string;
-
-    let newSortOrder: number;
-    if (overData?.type === "drop-zone") {
-      const maxSort = categoryItems
-        .filter((b) => b.id !== draggedId)
-        .reduce((max, b) => Math.max(max, b.sortOrder ?? 0), -1);
-      newSortOrder = maxSort + 1;
-    } else {
-      const overIndex = categoryItems.findIndex((b) => b.id === overId);
-      if (overIndex === -1) {
-        newSortOrder = categoryItems.length;
-      } else {
-        newSortOrder = overIndex;
-      }
-    }
-
-    const sameCategory = categoryItems.filter((b) => b.id !== draggedId);
-    const reordered = [...sameCategory];
-    const movedBm = { ...bm, tagId: targetTagId, sortOrder: newSortOrder };
-    reordered.splice(Math.min(newSortOrder, reordered.length), 0, movedBm);
-
-    const updatedIds = reordered.map((b) => b.id);
-    const idToIndex = new Map(updatedIds.map((id, i) => [id, i]));
-    const updatedItems = currentItems.map((b) => {
-      const idx = idToIndex.get(b.id);
-      if (idx !== undefined) {
-        return { ...b, tagId: targetTagId, tag: movedBm.tag, sortOrder: idx };
-      }
-      return b;
-    });
-
-    setItems(updatedItems);
-
-    try {
-      const moveResult = await moveBookmark(draggedId, targetTagId, newSortOrder, {
-        skipRevalidate: true,
-      });
-      if (moveResult.error) throw new Error(moveResult.error);
-      const reorderResult = await reorderBookmarks(updatedIds, { skipRevalidate: true });
-      if (reorderResult.error) throw new Error(reorderResult.error);
-    } catch {
-      setItems(currentItems);
-    }
-  }, []);
+  const {
+    sensors,
+    collisionDetection,
+    handleDragStart,
+    handleDragOver,
+    handleDragEnd,
+    activeBookmark,
+  } = useDragAndDrop({ items, setItems, allTagsState, setAllTagsState });
 
   const handleTagModalClose = useCallback(() => {
     setIsTagModalOpen(false);
@@ -623,8 +206,6 @@ export function BookmarkList({
     },
     [router, editingBookmarkId, allTagsState],
   );
-
-  const activeBookmark = activeId ? items.find((b) => b.id === activeId) : null;
 
   return (
     <div>

--- a/src/app/(dashboard)/bookmarks/CategoryDropZone.tsx
+++ b/src/app/(dashboard)/bookmarks/CategoryDropZone.tsx
@@ -1,0 +1,20 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { UNCATEGORIZED_KEY } from "./types";
+
+export function CategoryDropZone({ categoryKey }: { categoryKey: string }) {
+  const { setNodeRef, isOver } = useSortable({
+    id: `drop-zone-${categoryKey}`,
+    data: { type: "drop-zone", tagId: categoryKey === UNCATEGORIZED_KEY ? null : categoryKey },
+  });
+
+  if (!isOver) return <div ref={setNodeRef} className="h-1" />;
+
+  return (
+    <div
+      ref={setNodeRef}
+      className="rounded-md border-2 border-dashed border-blue-400 bg-blue-50 py-4 text-center text-xs text-blue-500"
+    >
+      ここにドロップ
+    </div>
+  );
+}

--- a/src/app/(dashboard)/bookmarks/CategoryGroup.tsx
+++ b/src/app/(dashboard)/bookmarks/CategoryGroup.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useState } from "react";
+import { getTagColor } from "@/lib/tag-colors";
+import { CategoryDropZone } from "./CategoryDropZone";
+import { DragHandleIcon } from "./DragHandleIcon";
+import { SortableBookmarkItem } from "./SortableBookmarkItem";
+import type { Bookmark, TagItem } from "./types";
+
+export function CategoryGroup({
+  categoryKey,
+  tag,
+  bookmarks,
+  isSearching,
+  onEdit,
+  onDelete,
+}: {
+  categoryKey: string;
+  tag: TagItem | null;
+  bookmarks: Bookmark[];
+  isSearching: boolean;
+  onEdit: (bm: Bookmark) => void;
+  onDelete: (bm: Bookmark) => void;
+}) {
+  const [collapsed, setCollapsed] = useState(false);
+  const color = tag ? getTagColor(tag.name) : null;
+  const isSortable = tag !== null;
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: `category-${categoryKey}`,
+    disabled: !isSortable,
+    data: { type: "category" },
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition: transition || undefined,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="mb-6">
+      <div className="mb-2 flex w-full items-center gap-2 border-b border-zinc-200 pb-1.5">
+        {isSortable && (
+          <button
+            type="button"
+            {...attributes}
+            {...listeners}
+            className="shrink-0 cursor-grab text-zinc-400 hover:text-zinc-600 active:cursor-grabbing"
+            aria-label="ドラッグしてカテゴリを並び替え"
+          >
+            <DragHandleIcon />
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => setCollapsed((prev) => !prev)}
+          className="flex flex-1 cursor-pointer items-center gap-2"
+        >
+          <span
+            className={`inline-block h-2.5 w-2.5 rounded-full ${color ? color.activeBg : "bg-zinc-400"}`}
+          />
+          <span className={`text-sm font-medium ${tag ? "text-zinc-900" : "text-zinc-500"}`}>
+            {tag ? tag.name : "未分類"}
+          </span>
+          <span className="text-xs text-zinc-400">{bookmarks.length}</span>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            className={`ml-auto text-zinc-400 transition-transform ${collapsed ? "-rotate-90" : ""}`}
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </button>
+      </div>
+
+      {!collapsed && (
+        <div className="pl-5">
+          <SortableContext
+            items={[...bookmarks.map((b) => b.id), `drop-zone-${categoryKey}`]}
+            strategy={verticalListSortingStrategy}
+          >
+            <ul className="flex flex-col gap-2">
+              {bookmarks.map((bm) => (
+                <SortableBookmarkItem
+                  key={bm.id}
+                  bm={bm}
+                  isSearching={isSearching}
+                  onEdit={onEdit}
+                  onDelete={onDelete}
+                />
+              ))}
+              <CategoryDropZone categoryKey={categoryKey} />
+            </ul>
+          </SortableContext>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/bookmarks/DragHandleIcon.tsx
+++ b/src/app/(dashboard)/bookmarks/DragHandleIcon.tsx
@@ -1,0 +1,14 @@
+export function DragHandleIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M8 6a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM8 12a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM8 18a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM20 6a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM20 12a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM20 18a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z" />
+    </svg>
+  );
+}

--- a/src/app/(dashboard)/bookmarks/SortableBookmarkItem.tsx
+++ b/src/app/(dashboard)/bookmarks/SortableBookmarkItem.tsx
@@ -1,0 +1,50 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { BookmarkItemContent } from "./BookmarkItemContent";
+import { DragHandleIcon } from "./DragHandleIcon";
+import type { Bookmark } from "./types";
+
+export function SortableBookmarkItem({
+  bm,
+  isSearching,
+  onEdit,
+  onDelete,
+}: {
+  bm: Bookmark;
+  isSearching: boolean;
+  onEdit: (bm: Bookmark) => void;
+  onDelete: (bm: Bookmark) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: bm.id,
+    disabled: isSearching,
+    data: { type: "bookmark", tagId: bm.tagId },
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition: transition || undefined,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-3 rounded-lg border border-zinc-200 bg-white px-4 py-3 hover:border-zinc-400 hover:bg-zinc-50"
+    >
+      {!isSearching && (
+        <button
+          type="button"
+          {...attributes}
+          {...listeners}
+          className="shrink-0 cursor-grab text-zinc-400 hover:text-zinc-600 active:cursor-grabbing"
+          aria-label="ドラッグして並び替え"
+        >
+          <DragHandleIcon />
+        </button>
+      )}
+      <BookmarkItemContent bm={bm} onEdit={onEdit} onDelete={onDelete} />
+    </li>
+  );
+}

--- a/src/app/(dashboard)/bookmarks/types.ts
+++ b/src/app/(dashboard)/bookmarks/types.ts
@@ -1,0 +1,20 @@
+export const UNCATEGORIZED_KEY = "__uncategorized__";
+
+export type Bookmark = {
+  id: string;
+  url: string;
+  title: string;
+  memo: string | null;
+  ogImage: string | null;
+  sortOrder: number;
+  tag: { id: string; name: string } | null;
+  tagId: string | null;
+};
+
+export type TagItem = { id: string; name: string };
+export type TagWithCount = { id: string; name: string; bookmarkCount: number };
+
+export type PendingDelete = {
+  bookmarks: Bookmark[];
+  timerId: ReturnType<typeof setTimeout>;
+};

--- a/src/app/(dashboard)/bookmarks/useDragAndDrop.ts
+++ b/src/app/(dashboard)/bookmarks/useDragAndDrop.ts
@@ -1,0 +1,205 @@
+import {
+  type CollisionDetection,
+  closestCenter,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { moveBookmark, reorderBookmarks, reorderTags } from "./actions";
+import type { Bookmark, TagItem } from "./types";
+
+export function useDragAndDrop({
+  items,
+  setItems,
+  allTagsState,
+  setAllTagsState,
+}: {
+  items: Bookmark[];
+  setItems: React.Dispatch<React.SetStateAction<Bookmark[]>>;
+  allTagsState: TagItem[];
+  setAllTagsState: React.Dispatch<React.SetStateAction<TagItem[]>>;
+}) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const collisionDetection: CollisionDetection = useCallback((args) => {
+    const activeData = args.active.data.current as { type: string } | undefined;
+    if (activeData?.type === "category") {
+      const categoryContainers = args.droppableContainers.filter(
+        (c) => (c.data.current as { type: string } | undefined)?.type === "category",
+      );
+      return closestCenter({ ...args, droppableContainers: categoryContainers });
+    }
+    return closestCenter(args);
+  }, []);
+
+  const itemsRef = useRef<Bookmark[]>(items);
+  useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
+
+  const allTagsRef = useRef<TagItem[]>(allTagsState);
+  useEffect(() => {
+    allTagsRef.current = allTagsState;
+  }, [allTagsState]);
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(event.active.id as string);
+  }, []);
+
+  const handleDragOver = useCallback(
+    (event: DragOverEvent) => {
+      const { active, over } = event;
+      if (!over) return;
+
+      const activeData = active.data.current as { type: string; tagId: string | null } | undefined;
+      const overData = over.data.current as { type: string; tagId: string | null } | undefined;
+      if (!activeData || activeData.type !== "bookmark") return;
+
+      let targetTagId: string | null | undefined;
+
+      if (overData?.type === "drop-zone") {
+        targetTagId = overData.tagId;
+      } else if (overData?.type === "bookmark") {
+        targetTagId = overData.tagId;
+      } else {
+        return;
+      }
+
+      if (targetTagId === undefined) return;
+      if (activeData.tagId === targetTagId) return;
+
+      const draggedId = active.id as string;
+      const newTag = targetTagId ? (allTagsState.find((t) => t.id === targetTagId) ?? null) : null;
+
+      setItems((prev) =>
+        prev.map((bm) =>
+          bm.id === draggedId ? { ...bm, tagId: targetTagId ?? null, tag: newTag } : bm,
+        ),
+      );
+    },
+    [allTagsState, setItems],
+  );
+
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      setActiveId(null);
+      const { active, over } = event;
+      if (!over) return;
+
+      const activeData = active.data.current as { type: string } | undefined;
+      if (activeData?.type === "category") {
+        const activeKey = (active.id as string).replace("category-", "");
+        const overKey = (over.id as string).replace("category-", "");
+        if (activeKey === overKey) return;
+
+        const oldTags = allTagsRef.current;
+        const oldIndex = oldTags.findIndex((t) => t.id === activeKey);
+        const overIndex = oldTags.findIndex((t) => t.id === overKey);
+        if (oldIndex === -1 || overIndex === -1) return;
+
+        const newTags = [...oldTags];
+        const [moved] = newTags.splice(oldIndex, 1);
+        newTags.splice(overIndex, 0, moved);
+        setAllTagsState(newTags);
+
+        try {
+          const result = await reorderTags(
+            newTags.map((t) => t.id),
+            { skipRevalidate: true },
+          );
+          if (result.error) throw new Error(result.error);
+        } catch {
+          setAllTagsState(oldTags);
+        }
+        return;
+      }
+
+      const draggedId = active.id as string;
+      const bm = itemsRef.current.find((b) => b.id === draggedId);
+      if (!bm) return;
+
+      const overData = over.data.current as { type: string; tagId: string | null } | undefined;
+
+      let targetTagId: string | null;
+      if (overData?.type === "drop-zone") {
+        targetTagId = overData.tagId;
+      } else if (overData?.type === "bookmark") {
+        targetTagId = overData.tagId;
+      } else {
+        targetTagId = bm.tagId;
+      }
+
+      const currentItems = itemsRef.current;
+      const categoryItems = currentItems
+        .filter((b) => b.tagId === targetTagId)
+        .toSorted((a, b) => a.sortOrder - b.sortOrder);
+      const overId = over.id as string;
+
+      let newSortOrder: number;
+      if (overData?.type === "drop-zone") {
+        const maxSort = categoryItems
+          .filter((b) => b.id !== draggedId)
+          .reduce((max, b) => Math.max(max, b.sortOrder ?? 0), -1);
+        newSortOrder = maxSort + 1;
+      } else {
+        const overIndex = categoryItems.findIndex((b) => b.id === overId);
+        if (overIndex === -1) {
+          newSortOrder = categoryItems.length;
+        } else {
+          newSortOrder = overIndex;
+        }
+      }
+
+      const sameCategory = categoryItems.filter((b) => b.id !== draggedId);
+      const reordered = [...sameCategory];
+      const movedBm = { ...bm, tagId: targetTagId, sortOrder: newSortOrder };
+      reordered.splice(Math.min(newSortOrder, reordered.length), 0, movedBm);
+
+      const updatedIds = reordered.map((b) => b.id);
+      const idToIndex = new Map(updatedIds.map((id, i) => [id, i]));
+      const updatedItems = currentItems.map((b) => {
+        const idx = idToIndex.get(b.id);
+        if (idx !== undefined) {
+          return { ...b, tagId: targetTagId, tag: movedBm.tag, sortOrder: idx };
+        }
+        return b;
+      });
+
+      setItems(updatedItems);
+
+      try {
+        const moveResult = await moveBookmark(draggedId, targetTagId, newSortOrder, {
+          skipRevalidate: true,
+        });
+        if (moveResult.error) throw new Error(moveResult.error);
+        const reorderResult = await reorderBookmarks(updatedIds, { skipRevalidate: true });
+        if (reorderResult.error) throw new Error(reorderResult.error);
+      } catch {
+        setItems(currentItems);
+      }
+    },
+    [setItems, setAllTagsState],
+  );
+
+  const activeBookmark = activeId ? items.find((b) => b.id === activeId) : null;
+
+  return {
+    sensors,
+    collisionDetection,
+    handleDragStart,
+    handleDragOver,
+    handleDragEnd,
+    activeBookmark,
+  };
+}


### PR DESCRIPTION
## Summary

- `BookmarkList.tsx`（786行）からコンポーネント・D&Dロジック・型定義を分離し367行に削減
- 新規7ファイル: `types.ts`, `DragHandleIcon.tsx`, `BookmarkItemContent.tsx`, `SortableBookmarkItem.tsx`, `CategoryDropZone.tsx`, `CategoryGroup.tsx`, `useDragAndDrop.ts`
- 機能変更なし

## Test plan

- [x] Biome lint パス
- [x] 全80テストパス
- [x] 手動動作確認完了（カテゴリグルーピング、D&D、CRUD、検索、モーダル）

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)