### PR TITLE
fix: Biome 2.5.1 マイグレーションと lint 警告修正

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -27,7 +27,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "correctness": {
         "noUnusedImports": "error",
         "noUnusedVariables": "error"

--- a/src/app/(dashboard)/bookmarks/useDragAndDrop.ts
+++ b/src/app/(dashboard)/bookmarks/useDragAndDrop.ts
@@ -64,7 +64,7 @@ export function useDragAndDrop({
 
       const activeData = active.data.current as { type: string; tagId: string | null } | undefined;
       const overData = over.data.current as { type: string; tagId: string | null } | undefined;
-      if (!activeData || activeData.type !== "bookmark") return;
+      if (activeData?.type !== "bookmark") return;
 
       let targetTagId: string | null | undefined;
 


### PR DESCRIPTION
## Summary
- `biome.json` のスキーマバージョンを 2.4.12 → 2.5.1 に更新（`biome migrate` で自動移行）
- 非推奨の `recommended` フィールドを `preset` に移行
- `useDragAndDrop.ts` の optional chain lint 警告を修正

## Test plan
- [x] `npm run lint` でエラー・警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)