### PR TITLE
[T98] E2E テスト基盤の構築（Playwright + Clerk）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 !.yarn/versions
 
 # testing
+/e2e/.auth/
 /playwright-report/
 /test-results/
 /blob-report/

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -10,6 +10,8 @@
     "includes": [
       "src/**",
       "prisma/**",
+      "e2e/**",
+      "playwright.config.ts",
       ".vscode/**",
       ".devcontainer/**",
       "!node_modules",

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+
+/** シードのテストユーザー共通パスワード（prisma/seed.ts と一致させる） */
+export const SEED_PASSWORD = "Yakitori2026";
+
+/** ユーザー別セッション（storageState）の保存先 */
+export const AUTH_DIR = "e2e/.auth";
+
+/**
+ * テストユーザー（prisma/seed.ts と一致させる）
+ * - bonjiri: 機能テスト全般（参照系）
+ * - tsukune: ユーザー分離確認
+ * - tebasaki: 破壊的操作テスト（作成・削除・並び替え）
+ */
+export type Role = "bonjiri" | "tsukune" | "tebasaki";
+
+export const USERS: Record<Role, { email: string }> = {
+  bonjiri: { email: "bonjiri@example.com" },
+  tsukune: { email: "tsukune@example.com" },
+  tebasaki: { email: "tebasaki@example.com" },
+};
+
+export function authState(role: Role): string {
+  return `${AUTH_DIR}/${role}.json`;
+}
+
+export { expect, test };

--- a/e2e/global.setup.ts
+++ b/e2e/global.setup.ts
@@ -1,0 +1,40 @@
+import { execSync } from "node:child_process";
+import { clerk, clerkSetup, setupClerkTestingToken } from "@clerk/testing/playwright";
+import { expect, test as setup } from "@playwright/test";
+
+import { authState, type Role, SEED_PASSWORD, USERS } from "./fixtures";
+
+// Clerk Testing Token の準備とシード投入（スイート開始前に1回）
+setup("prepare clerk and seed", async () => {
+  const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+  if (!publishableKey) {
+    throw new Error(
+      "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY が未設定です。E2E 実行前に .env を確認してください。",
+    );
+  }
+  if (process.env.MOCK_USER_ID || process.env.MOCK_USER_EMAIL) {
+    throw new Error(
+      "MOCK_USER_ID / MOCK_USER_EMAIL が設定されています。E2E は Clerk 認証を使うため .env から外してください。",
+    );
+  }
+  await clerkSetup({ publishableKey });
+  execSync("npx tsx prisma/seed.ts", { cwd: process.cwd(), stdio: "inherit" });
+});
+
+// ユーザーごとにログインし、セッションを storageState として保存する
+for (const [role, { email }] of Object.entries(USERS) as [Role, { email: string }][]) {
+  setup(`authenticate as ${role}`, async ({ page }) => {
+    await setupClerkTestingToken({ page });
+    await page.goto("/sign-in");
+    await clerk.signIn({
+      page,
+      signInParams: { strategy: "password", identifier: email, password: SEED_PASSWORD },
+    });
+
+    // ログイン済みセッションでアプリに入れることを確認
+    await page.goto("/bookmarks");
+    await expect(page.getByText(email)).toBeVisible();
+
+    await page.context().storageState({ path: authState(role) });
+  });
+}

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,36 @@
+import { authState, expect, test, USERS } from "./fixtures";
+
+/**
+ * 基盤のスモークテスト
+ * 各ユーザーの保存済みセッションで /bookmarks が表示されることを確認する。
+ */
+
+test.describe("bonjiri のセッション", () => {
+  test.use({ storageState: authState("bonjiri") });
+
+  test("/bookmarks が表示され、シードのブックマークが見える", async ({ page }) => {
+    await page.goto("/bookmarks");
+    await expect(page.getByText(USERS.bonjiri.email)).toBeVisible();
+    await expect(page.getByText("Next.js", { exact: true })).toBeVisible();
+  });
+});
+
+test.describe("tsukune のセッション", () => {
+  test.use({ storageState: authState("tsukune") });
+
+  test("/bookmarks が表示され、シードのブックマークが見える", async ({ page }) => {
+    await page.goto("/bookmarks");
+    await expect(page.getByText(USERS.tsukune.email)).toBeVisible();
+    await expect(page.getByText("Figma", { exact: true })).toBeVisible();
+  });
+});
+
+test.describe("tebasaki のセッション", () => {
+  test.use({ storageState: authState("tebasaki") });
+
+  test("/bookmarks が表示され、シードのブックマークが見える", async ({ page }) => {
+    await page.goto("/bookmarks");
+    await expect(page.getByText(USERS.tebasaki.email)).toBeVisible();
+    await expect(page.getByText("TypeScript", { exact: true })).toBeVisible();
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,8 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   // E2E テスト用サーバーが別の distDir を使えるようにする（.next ロック競合を防ぐ）
   distDir: process.env.NEXT_DIST_DIR ?? ".next",
+  // ブラウザログのターミナル転送を無効化（E2E 実行時の Clerk 開発キー警告ノイズを抑止）
+  logging: { browserToTerminal: false },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.2",
+        "@clerk/testing": "^2.2.3",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^26",
         "@types/react": "^19",
@@ -118,9 +120,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -138,9 +137,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -158,9 +154,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -178,9 +171,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -246,12 +236,12 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.10.0.tgz",
-      "integrity": "sha512-+No8bg+3SQ76zfu199l4lwpi3z+RqmO8N33CDXPkAnhXt6cAZu4HPT0WvZ/GDpbi7ZqpDmmP9yXpCQNGwEd0+g==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.11.0.tgz",
+      "integrity": "sha512-msK+Mvc8tmX3o8UTL6r9h7dodW9vPLvDjyVWLM0yLe5kuvvV5ag70O1qt5SXTCZd7HruS3MAuwUzn3PoQHoT3g==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.23.0",
+        "@clerk/shared": "^4.24.0",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -298,9 +288,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.23.0.tgz",
-      "integrity": "sha512-v4roxB9AwEVq56luLc9MtQ+RkVR66XZJGAfTbQXD0ArdW+fs1P/FhlKwm6OQfvDFNiCCVZA6GoP648t9dGtfrw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.24.0.tgz",
+      "integrity": "sha512-QgAihmKS4ld3YSqSPMaKnzU4RGV+60k5khcjiz0xi4BCUST+UJAbV8f3Hw0osxq/Rw9rsxmRlcoxhEMsN5SOFA==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/query-core": "^5.100.6",
@@ -324,6 +314,46 @@
         }
       }
     },
+    "node_modules/@clerk/testing": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@clerk/testing/-/testing-2.2.3.tgz",
+      "integrity": "sha512-W8r9nYeclIy6gl7TK+7dsOoeK2PLsw7CxH6urLykkFJ+R1CSMI8SCeHNEnwyCOb+XUYxeCnHP9eX6KC6fO1Q0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^3.11.0",
+        "@clerk/shared": "^4.24.0",
+        "dotenv": "17.2.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1",
+        "cypress": "^13 || ^14 || ^15"
+      },
+      "peerDependenciesMeta": {
+        "@playwright/test": {
+          "optional": true
+        },
+        "cypress": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/testing/node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
@@ -341,6 +371,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -381,7 +412,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
       "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.1",
@@ -1042,9 +1074,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1060,9 +1089,6 @@
       "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1080,9 +1106,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1098,9 +1121,6 @@
       "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1151,6 +1171,23 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prisma/adapter-neon": {
@@ -1905,9 +1942,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1925,9 +1959,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1945,9 +1976,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1965,9 +1993,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2005,27 +2030,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -2173,6 +2177,7 @@
       "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -2182,6 +2187,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2192,6 +2198,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2809,6 +2816,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3218,6 +3226,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
       "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.10",
         "@swc/helpers": "0.5.15",
@@ -3344,6 +3353,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3360,6 +3370,53 @@
         "confbox": "^0.2.4",
         "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {
@@ -3419,6 +3476,7 @@
       "integrity": "sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.8.0",
         "@prisma/dev": "0.24.3",
@@ -3494,6 +3552,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3503,6 +3562,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4362,6 +4422,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4397,6 +4458,7 @@
       "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:shots": "SHOTS=1 playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@clerk/nextjs": "^7.5.12",
@@ -34,6 +37,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.2",
+    "@clerk/testing": "^2.2.3",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^26",
     "@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig, devices } from "@playwright/test";
+import { config as loadEnv } from "dotenv";
+
+loadEnv();
+
+const BASE_URL = process.env.E2E_BASE_URL ?? "http://localhost:3000";
+
+/**
+ * E2E テスト設定（ローカル専用・devcontainer 内で実行）
+ *
+ * - 認証は @clerk/testing でプログラム的に行い、ユーザー別セッションを e2e/.auth に保存する
+ * - シードはグローバルセットアップでスイート開始前に1回実行する
+ * - データ競合を避けるため直列実行（workers: 1）
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: [["list"], ["html", { open: "never" }]],
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    // 既定は失敗時のみ。SHOTS=1 のときは全テストで終了時スクショを取得する（目視レビュー用）
+    screenshot: process.env.SHOTS ? "on" : "only-on-failure",
+  },
+  projects: [
+    // 認証セッション生成とシードを行うセットアップ
+    { name: "setup", testMatch: /global\.setup\.ts/ },
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+      dependencies: ["setup"],
+    },
+  ],
+  // dev サーバーが未起動なら自動起動する。既に起動済みなら再利用する
+  webServer: {
+    command: "npm run dev",
+    url: BASE_URL,
+    reuseExistingServer: true,
+    timeout: 120_000,
+    // 手動起動中の dev サーバー（.next）とロック競合しないよう別 distDir を使う
+    env: { NEXT_DIST_DIR: ".next-e2e" },
+    // dev サーバーの stdout（Clerk 開発キー警告等）を抑止する。
+    // 起動判定は url 待ちで行うため影響なし。stderr は既定のまま（起動エラーは表示される）。
+    stdout: "ignore",
+  },
+});

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -20,52 +20,52 @@ const clerk = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY });
 // テストユーザーの共通パスワード
 const SEED_PASSWORD = "Yakitori2026";
 
-// ---- user1: タグフィルター・D&D・検索・削除・一括操作の検証用 ----
+type SeedBookmark = {
+  url: string;
+  title: string;
+  memo: string;
+  tag?: string;
+};
+
+// ---- user1: カテゴリ表示・D&D・検索の検証用（参照系） ----
 const USER1_EMAIL = "bonjiri@example.com";
 
 const USER1_TAGS = ["Frontend", "Backend"];
 
-const USER1_BOOKMARKS: {
-  url: string;
-  title: string;
-  memo: string;
-  tags: string[];
-}[] = [
+const USER1_BOOKMARKS: SeedBookmark[] = [
   {
     url: "https://nextjs.org",
     title: "Next.js",
     memo: "React フレームワーク",
-    tags: ["Frontend"],
+    tag: "Frontend",
   },
   {
     url: "https://vercel.com",
     title: "Vercel",
     memo: "デプロイプラットフォーム",
-    tags: ["Frontend"],
+    tag: "Frontend",
   },
   {
     url: "https://www.prisma.io",
     title: "Prisma",
     memo: "TypeScript 向け ORM",
-    tags: ["Backend"],
+    tag: "Backend",
   },
   {
     url: "https://neon.tech",
     title: "Neon",
     memo: "サーバーレス PostgreSQL",
-    tags: ["Frontend", "Backend"], // AND フィルターテスト用
+    tag: "Backend",
   },
   {
     url: "https://github.com",
     title: "GitHub",
-    memo: "コードホスティング",
-    tags: [], // タグなしフィルターテスト用
+    memo: "コードホスティング", // 未分類グループテスト用
   },
   {
     url: "https://playwright.dev",
     title: "Playwright",
-    memo: "E2E テストフレームワーク",
-    tags: [], // タグなしフィルターテスト用
+    memo: "E2E テストフレームワーク", // 未分類グループテスト用
   },
 ];
 
@@ -74,23 +74,17 @@ const USER2_EMAIL = "tsukune@example.com";
 
 const USER2_TAGS = ["Design"];
 
-const USER2_BOOKMARKS: {
-  url: string;
-  title: string;
-  memo: string;
-  tags: string[];
-}[] = [
+const USER2_BOOKMARKS: SeedBookmark[] = [
   {
     url: "https://www.figma.com",
     title: "Figma",
     memo: "デザインツール",
-    tags: ["Design"],
+    tag: "Design",
   },
   {
     url: "https://developer.mozilla.org",
     title: "MDN Web Docs",
     memo: "Web API リファレンス",
-    tags: [],
   },
 ];
 
@@ -99,41 +93,33 @@ const USER3_EMAIL = "tebasaki@example.com";
 
 const USER3_TAGS = ["Tools", "Docs"];
 
-const USER3_BOOKMARKS: {
-  url: string;
-  title: string;
-  memo: string;
-  tags: string[];
-}[] = [
+const USER3_BOOKMARKS: SeedBookmark[] = [
   {
     url: "https://www.typescriptlang.org",
     title: "TypeScript",
     memo: "型付き JavaScript",
-    tags: ["Tools"],
+    tag: "Tools",
   },
   {
     url: "https://nodejs.org",
     title: "Node.js",
     memo: "JavaScript ランタイム",
-    tags: ["Docs"],
+    tag: "Docs",
   },
   {
     url: "https://vitejs.dev",
     title: "Vite",
     memo: "ビルドツール",
-    tags: [],
   },
   {
     url: "https://biome.dev",
     title: "Biome",
     memo: "リンター・フォーマッタ",
-    tags: [],
   },
   {
     url: "https://www.npmjs.com",
     title: "npm",
     memo: "パッケージマネージャ",
-    tags: [],
   },
 ];
 
@@ -151,11 +137,7 @@ async function upsertClerkUser(email: string): Promise<string> {
   return created.id;
 }
 
-async function seedUser(
-  email: string,
-  tagNames: string[],
-  bookmarks: { url: string; title: string; memo: string; tags: string[] }[],
-) {
+async function seedUser(email: string, tagNames: string[], bookmarks: SeedBookmark[]) {
   const clerkId = await upsertClerkUser(email);
 
   // DB にユーザーが存在しなければ作成、存在すれば clerkId を同期
@@ -169,16 +151,25 @@ async function seedUser(
   await prisma.bookmark.deleteMany({ where: { userId: user.id } });
   await prisma.tag.deleteMany({ where: { userId: user.id } });
 
-  // タグを作成
+  // タグ（カテゴリ）を作成
   const tagMap = new Map<string, string>();
-  for (const name of tagNames) {
-    const tag = await prisma.tag.create({ data: { name, userId: user.id } });
-    tagMap.set(name, tag.id);
+  for (let i = 0; i < tagNames.length; i++) {
+    const tag = await prisma.tag.create({
+      data: { name: tagNames[i], sortOrder: i, userId: user.id },
+    });
+    tagMap.set(tagNames[i], tag.id);
   }
 
   // ブックマークをタグ込みで作成
   for (let i = 0; i < bookmarks.length; i++) {
-    const { url, title, memo, tags } = bookmarks[i];
+    const { url, title, memo, tag } = bookmarks[i];
+    let tagId: string | null = null;
+    if (tag !== undefined) {
+      tagId = tagMap.get(tag) ?? null;
+      if (tagId === null) {
+        throw new Error(`Unknown tag "${tag}" for bookmark "${title}" (${url}) of user ${email}`);
+      }
+    }
     await prisma.bookmark.create({
       data: {
         url,
@@ -186,17 +177,7 @@ async function seedUser(
         memo,
         sortOrder: i,
         userId: user.id,
-        tags: {
-          create: tags.map((name) => {
-            const tagId = tagMap.get(name);
-            if (tagId === undefined) {
-              throw new Error(
-                `Unknown tag "${name}" for bookmark "${title}" (${url}) of user ${email}`,
-              );
-            }
-            return { tagId };
-          }),
-        },
+        tagId,
       },
     });
   }


### PR DESCRIPTION
@
## Summary

Phase 7「E2E テストのコード化」の基盤スライス。手動（Playwright MCP）で実施していた E2E を Playwright でコード化するための基盤を構築した（daily-hub ot-nemoto/daily-hub#312 と同構成）。**ローカル専用・devcontainer 内で完結**（CI では実行しない）。

Closes 対象: #236

## 内容

### 基盤
- `@playwright/test` + `@clerk/testing` を導入
- `playwright.config.ts`: `webServer` 自動起動（`NEXT_DIST_DIR=.next-e2e` でロック競合回避・起動済みなら再利用）、`workers: 1` 直列、`screenshot: "only-on-failure"`（`SHOTS=1` で全テスト終了時スクショ）
- `e2e/global.setup.ts`: `clerkSetup()` → シード投入 → bonjiri / tsukune / tebasaki のログインセッションを `e2e/.auth/` に storageState 保存。`clerk.signIn()` によるプログラム的ログイン（UI 非経由）。`MOCK_USER_ID` / `MOCK_USER_EMAIL` 設定時はエラーで停止するガード付き
- `e2e/fixtures.ts`: テストユーザー定義・`authState()`・共通 export
- `e2e/smoke.spec.ts`: 各ユーザーのセッションで `/bookmarks` が表示されシードデータが見えることを確認
- scripts: `test:e2e` / `test:e2e:shots` / `test:e2e:ui`

### シード追従（prisma/seed.ts）
develop 最新化でスキーマが変わっていたため現行スキーマに追従:
- 多対多 `tags` → 単一 `tagId`（Neon の複数タグは Backend 単一に変更）
- `Tag.sortOrder` を投入順で設定
- 投入件数・ユーザー構成は従来どおり（bonjiri 6件 / tsukune 2件 / tebasaki 5件）

### その他
- `next.config.ts`: `logging.browserToTerminal: false`（E2E 実行時の Clerk 開発キー警告ノイズ抑止）
- `biome.json`: lint 対象に `e2e/**`・`playwright.config.ts` を追加
- `.gitignore`: `e2e/.auth/` を追加

## Test plan

devcontainer 内・node ユーザーで実行済み。

- [x] `npm run test:e2e` 7 passed × 2回連続（順序非依存・シード冪等を確認）
- [x] `npm test`（ユニット）144 passed
- [x] `npm run check`（biome）クリーン

## 補足

- 初回のみ `npx playwright install chromium`（+ 必要なら root で `npx playwright install-deps chromium`）が必要
- 各機能の spec コード化は後続スライス（#237〜#240）、ドキュメント刷新は #241 で実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@