### PR TITLE
docs: 残りの重複・コード複製・陳腐化を整理 (T106)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,23 +77,7 @@ Client (Browser)
 
 ## 環境変数
 
-```env
-# Database（Neon）
-DATABASE_URL=       # 接続プール URL（ランタイム用）
-DIRECT_URL=         # 直接接続 URL（prisma migrate 用）
-
-# Clerk
-NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
-CLERK_SECRET_KEY=
-NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
-NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/bookmarks
-
-# ローカル開発用認証バイパス（任意、どちらか一方を設定）
-# MOCK_USER_ID="<DB の users.id>"
-# MOCK_USER_EMAIL="your@example.com"
-```
-
-セットアップ手順・DB 操作・デプロイ手順の詳細は [`docs/development.md`](./development.md) を参照。
+環境変数（`DATABASE_URL` / `DIRECT_URL` / Clerk 関連 / 開発用モックバイパス）の一覧とセットアップ・DB 操作・デプロイ手順は [`docs/development.md`](./development.md) を正とする。
 
 ## バージョン固有仕様・既知のパターン
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -19,6 +19,7 @@ Clerk によるメール/パスワード認証を使用する。
 | `/sign-in/**` | 公開（認証不要） |
 | `/sign-up/**` | 公開（認証不要） |
 | `/auth-error` | 公開（認証不要） |
+| `/api/bookmarks/**` | 公開（Clerk 認証は不要。API キー認証で保護。[`docs/api.md`](api.md) 参照） |
 | 上記以外すべて | 認証必須（未認証は Clerk のサインイン画面へリダイレクト） |
 
 ### 開発環境のモックバイパス
@@ -29,19 +30,7 @@ Clerk によるメール/パスワード認証を使用する。
 
 ## セッション管理
 
-`src/lib/auth.ts` の `getSession()` を使用する。
-
-```ts
-getSession(): Promise<Session | null>
-
-type Session = {
-  user: {
-    id: string;       // DB の User.id（CUID）
-    name: string | null;
-    email: string;
-  };
-};
-```
+`src/lib/auth.ts` の `getSession()` を使う（戻り値 `Session` の型定義はコードを正とする）。返すのは DB の `User.id`（CUID）・`name`・`email` を含むユーザー情報、未認証時は `null`。
 
 ### 処理フロー
 
@@ -52,15 +41,10 @@ type Session = {
 
 ### 利用パターン
 
-```ts
-// Server Action での典型的な使い方
-const session = await getSession();
-if (!session) redirect("/sign-in");
-// session.user.id で自ユーザーを特定
-```
+- Server Action / Server Component の先頭で `getSession()` を呼び、未認証なら `redirect("/sign-in")` する。以降は `session.user.id` で自ユーザーを特定する
 
 ---
 
 ## ユーザーデータ分離
 
-認証はロールなしのユーザー認証。各ユーザーは自分のデータのみにアクセスできる。DB アクセスでは `where` に `userId` を含めるか、取得後に所有者の `userId` を検証する。
+認証はロールなしのユーザー認証で、各ユーザーは自分のデータのみアクセスできる。DB アクセスの `where` に `userId` を含める等の具体ルールは [`CLAUDE.md` のセキュリティルール](../CLAUDE.md#セキュリティルール) を正とする。

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -26,6 +26,7 @@ flowchart TD
     ADD_MODAL[追加モーダル]:::modal
     EDIT_MODAL[編集モーダル]:::modal
     TAG_MODAL[カテゴリ管理モーダル]:::modal
+    SETTINGS_MODAL[設定モーダル（API キー）]:::modal
 
     UNAUTH -->|Clerk Middleware| LOGIN
     LOGIN -->|ログイン成功| LIST
@@ -39,14 +40,17 @@ flowchart TD
     ADD_MODAL -->|保存成功/キャンセル/ESC/×| LIST
     EDIT_MODAL -->|保存成功/キャンセル/ESC/×| LIST
     TAG_MODAL -->|閉じる/ESC/×| LIST
+    SETTINGS_MODAL -->|閉じる/ESC/×| LIST
 
     subgraph Header ["Header（認証済み画面共通）"]
         direction LR
         H_APP(アプリ名):::nav
         H_EMAIL(メールアドレス):::nav
+        H_SETTINGS(設定ボタン):::nav
         H_LOGOUT(ログアウト):::nav
     end
 
+    H_SETTINGS -->|設定モーダルを開く| SETTINGS_MODAL
     H_LOGOUT -->|Clerk サインアウト| LOGIN
 ```
 


### PR DESCRIPTION
## Summary

[#250 T106](https://github.com/ot-nemoto/link-hub/issues/250) docs 全体監査で見つかった残りの重複・コード複製・陳腐化を整理する。ファイル構成は変えず内容のみ整える。

### A. 重複の統合
- `docs/architecture.md` の環境変数 `.env` ブロックが `docs/development.md` と完全重複 → `development.md` を正とし、`architecture.md` はポインタのみに
- ユーザーデータ分離ルールの分散 → `auth.md` の該当節を `CLAUDE.md` のセキュリティルールへのポインタに簡潔化

### B. コード複製の削減
- `docs/auth.md` の `Session` 型・`getSession()` シグネチャのコードスニペットを削除（型はコードが正）。認証フロー・保護ルート・分離方針（intent）は残す

### C. 陳腐化の修正（正確性）
- `docs/auth.md` の保護対象ルートに T89 の `/api/bookmarks`（public・API キー認証）を追記（「上記以外すべて認証必須」の不正確を修正）
- `docs/ui.md` の画面遷移図に設定ボタン→設定モーダル（API キー）を反映

## 補足（レビュー観点）
- ドキュメントのみの変更。コード・テストへの影響なし
- `npm run check`（Biome）クリーン
- `architecture.md` に `.env` の重複ブロックが残っていないことを確認（`DATABASE_URL=` は `development.md` のみ）
- ファイル構成は不変（7 core docs 維持。auth/architecture/development は役割が明確なため統合しない）

## Test plan
- [x] `npm run check` パス
- [x] 環境変数の重複解消・除去した節への参照崩れなしを確認

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)