### PR TITLE
feat: ブックマーク書き込み REST API を追加 (T108)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -32,7 +32,7 @@
 
 | ステータス | 条件 |
 |-----------|------|
-| 400 | バリデーションエラー（`url`/`title` 不正、`ids` 未指定、ボディ不正 等） |
+| 400 | バリデーションエラー（`url`/`title` 不正、`tagId` が文字列/null 以外、`ids` 未指定、ボディ不正 等） |
 | 401 | API キーが未指定・無効 |
 | 403 | 他ユーザーのリソースを操作しようとした |
 | 404 | 対象リソースが存在しない |
@@ -90,7 +90,7 @@ curl -s -H "Authorization: Bearer ${LH_API_KEY}" http://localhost:3000/api/bookm
 | `title` | string | ✅ | タイトル |
 | `memo` | string | - | メモ |
 | `ogImage` | string | - | OGP 画像 URL |
-| `tagId` | string \| null | - | カテゴリ ID（他ユーザーのカテゴリは無視され未分類になる） |
+| `tagId` | string \| null | - | カテゴリ ID（`null` は未分類・他ユーザーのカテゴリは無視され未分類になる）。文字列/null 以外は 400 |
 | `hideOgImage` | boolean | - | 一覧で OGP 画像を隠すか |
 
 ```bash
@@ -123,10 +123,14 @@ curl -s -X DELETE -H "Authorization: Bearer ${LH_API_KEY}" \
 
 ## `PATCH /api/bookmarks/:id` — 更新
 
-リクエストボディは `POST` と同じ（`url`・`title` は必須）。`tagId` と組み合わせてカテゴリ移動、`sortOrder` は非対応（並び替えは別途 reorder API を予定）。
+リクエストボディは `POST` と同じ（`url`・`title` は必須）。`tagId` でカテゴリ移動が可能。`sortOrder`（並び順）は非対応（並び替えは別途 reorder API を予定）。
 
-- `tagId` を省略すると既存カテゴリを保持、`null` を指定すると未分類化する
-- `ogImage` を省略すると既存値を保持する
+`url`・`title` 以外のフィールドは**キーを省略すると既存値を保持**し、明示的に送ると更新する（部分更新）:
+
+- `tagId`: 省略で保持、`null` で未分類化
+- `memo`: 省略で保持、空文字 `""` でクリア
+- `ogImage`: 省略で保持
+- `hideOgImage`: 省略で保持
 
 ```bash
 curl -s -X PATCH -H "Authorization: Bearer ${LH_API_KEY}" \

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,37 +1,62 @@
 # 外部 REST API
 
-外部連携用の REST API エンドポイント定義（API キー認証）。
+外部連携用の REST API エンドポイント定義（API キー認証）。API キーがあれば UI を介さずブックマークを操作できる。
 
-書き込み操作はすべて **Server Actions**（`actions.ts`）で実装している。Server Actions の仕様は [`docs/actions.md`](actions.md) を参照。
+書き込み系の業務ロジックは `src/lib/` に集約し、Server Actions（UI 用）と REST API（外部用）が同じ関数を共有する。Server Actions の仕様は [`docs/actions.md`](actions.md) を参照。
 
 ## 認証
 
 - `Authorization: Bearer <api-key>` ヘッダー必須
 - API キーはアプリのヘッダー「API キー」モーダルで生成・再生成できる（1 ユーザー 1 キー・平文保持）
 - キーが無効・未指定の場合は `401 Unauthorized`
-- `/api/bookmarks` は `proxy.ts` の public ルートに含め、Clerk 認証ではなく API キー認証で保護する
+- `/api/bookmarks(.*)` は `proxy.ts` の public ルートに含め、Clerk 認証ではなく API キー認証で保護する
+
+## 共通仕様
+
+- リクエスト・レスポンスボディはすべて JSON（`Content-Type: application/json`）
+- ブックマークのレスポンス形式は全エンドポイント共通（下表）
+
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `id` | string | ブックマーク ID |
+| `url` | string | URL |
+| `title` | string | タイトル |
+| `memo` | string \| null | メモ |
+| `ogImage` | string \| null | OGP 画像 URL |
+| `category` | `{ id, name }` \| null | カテゴリ（未分類は null） |
+| `createdAt` | string | 作成日時（ISO 8601） |
+
+### エラーレスポンス
+
+`{ "error": "<メッセージ>" }` を返す。ステータスの割り当ては共通。
+
+| ステータス | 条件 |
+|-----------|------|
+| 400 | バリデーションエラー（`url`/`title` 不正、`ids` 未指定、ボディ不正 等） |
+| 401 | API キーが未指定・無効 |
+| 403 | 他ユーザーのリソースを操作しようとした |
+| 404 | 対象リソースが存在しない |
 
 ## エンドポイント一覧
 
-| メソッド | パス | 概要 | 認証 |
-|---------|------|------|------|
-| `GET` | `/api/bookmarks` | 認証ユーザーのブックマーク一覧を取得 | API キー |
+| メソッド | パス | 概要 |
+|---------|------|------|
+| `GET` | `/api/bookmarks` | ブックマーク一覧を取得 |
+| `POST` | `/api/bookmarks` | ブックマークを作成 |
+| `DELETE` | `/api/bookmarks?ids=a,b,c` | 複数ブックマークを一括削除（ゴミ箱へ） |
+| `PATCH` | `/api/bookmarks/:id` | ブックマークを更新（カテゴリ移動・並び順変更を含む） |
+| `DELETE` | `/api/bookmarks/:id` | ブックマークを削除（ゴミ箱へ） |
+
+> 削除はソフトデリート（ゴミ箱へ移動）。ゴミ箱の一覧・復元・完全削除、並び替え、カテゴリ API は別 Issue で追加予定。
 
 ---
 
-## `GET /api/bookmarks` — ブックマーク一覧取得
+## `GET /api/bookmarks` — 一覧取得
 
-認証ユーザーの**未削除**ブックマークを JSON で返す。
-
-**認証:** `Authorization: Bearer <api-key>` ヘッダー必須
-
-### リクエスト例
-
-API キーを環境変数に設定して呼び出す（キーはヘッダーの「API キー」モーダルで発行）。
+認証ユーザーの**未削除**ブックマークを配列で返す。
 
 ```bash
 export LH_API_KEY="550e8400-e29b-41d4-a716-446655440000"
-
 curl -s -H "Authorization: Bearer ${LH_API_KEY}" http://localhost:3000/api/bookmarks | jq
 ```
 
@@ -53,18 +78,78 @@ curl -s -H "Authorization: Bearer ${LH_API_KEY}" http://localhost:3000/api/bookm
 }
 ```
 
-| フィールド | 型 | 説明 |
-|-----------|-----|------|
-| `id` | string | ブックマーク ID |
-| `url` | string | URL |
-| `title` | string | タイトル |
-| `memo` | string \| null | メモ |
-| `ogImage` | string \| null | OGP 画像 URL |
-| `category` | `{ id, name }` \| null | カテゴリ（未分類は null） |
-| `createdAt` | string | 作成日時（ISO 8601） |
+---
 
-### エラーレスポンス
+## `POST /api/bookmarks` — 作成
 
-| ステータス | ボディ | 条件 |
-|-----------|--------|------|
-| 401 | `{ "error": "Unauthorized" }` | API キーが未指定・無効 |
+### リクエストボディ
+
+| フィールド | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `url` | string | ✅ | `http`/`https` の URL |
+| `title` | string | ✅ | タイトル |
+| `memo` | string | - | メモ |
+| `ogImage` | string | - | OGP 画像 URL |
+| `tagId` | string \| null | - | カテゴリ ID（他ユーザーのカテゴリは無視され未分類になる） |
+| `hideOgImage` | boolean | - | 一覧で OGP 画像を隠すか |
+
+```bash
+curl -s -X POST -H "Authorization: Bearer ${LH_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com","title":"Example","memo":"メモ"}' \
+  http://localhost:3000/api/bookmarks | jq
+```
+
+### レスポンス（201）
+
+作成されたブックマーク（共通形式）を返す。
+
+---
+
+## `DELETE /api/bookmarks?ids=a,b,c` — 一括削除
+
+`ids` クエリにカンマ区切りの ID を指定し、まとめてゴミ箱へ移動する（ソフトデリート）。自ユーザー所有分のみが対象。
+
+```bash
+curl -s -X DELETE -H "Authorization: Bearer ${LH_API_KEY}" \
+  "http://localhost:3000/api/bookmarks?ids=clxxxx,clyyyy"
+```
+
+### レスポンス（204）
+
+ボディなし。
+
+---
+
+## `PATCH /api/bookmarks/:id` — 更新
+
+リクエストボディは `POST` と同じ（`url`・`title` は必須）。`tagId` と組み合わせてカテゴリ移動、`sortOrder` は非対応（並び替えは別途 reorder API を予定）。
+
+- `tagId` を省略すると既存カテゴリを保持、`null` を指定すると未分類化する
+- `ogImage` を省略すると既存値を保持する
+
+```bash
+curl -s -X PATCH -H "Authorization: Bearer ${LH_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com","title":"新しいタイトル","tagId":"clyyyy"}' \
+  http://localhost:3000/api/bookmarks/clxxxx | jq
+```
+
+### レスポンス（200）
+
+更新後のブックマーク（共通形式）を返す。
+
+---
+
+## `DELETE /api/bookmarks/:id` — 削除
+
+対象ブックマークをゴミ箱へ移動する（ソフトデリート）。
+
+```bash
+curl -s -X DELETE -H "Authorization: Bearer ${LH_API_KEY}" \
+  http://localhost:3000/api/bookmarks/clxxxx
+```
+
+### レスポンス（204）
+
+ボディなし。

--- a/src/app/api/bookmarks/[id]/route.test.ts
+++ b/src/app/api/bookmarks/[id]/route.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DELETE, PATCH } from "./route";
+
+vi.mock("@/lib/api-auth", () => ({ getUserByApiKey: vi.fn() }));
+vi.mock("@/lib/bookmarks", () => ({
+  updateBookmark: vi.fn(),
+  deleteBookmark: vi.fn(),
+}));
+
+vi.stubEnv("DATABASE_URL", "postgresql://test");
+
+import { getUserByApiKey } from "@/lib/api-auth";
+import { deleteBookmark, updateBookmark } from "@/lib/bookmarks";
+
+const mockGetUser = vi.mocked(getUserByApiKey);
+const mockUpdate = vi.mocked(updateBookmark);
+const mockDelete = vi.mocked(deleteBookmark);
+
+const record = {
+  id: "bm_1",
+  url: "https://a.com",
+  title: "Updated",
+  memo: null,
+  ogImage: null,
+  createdAt: new Date("2026-01-02T03:04:05.000Z"),
+  tag: null,
+};
+
+function patchReq(body: unknown) {
+  return { json: async () => body } as never;
+}
+
+const ctx = { params: Promise.resolve({ id: "bm_1" }) };
+
+describe("PATCH /api/bookmarks/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("未認証の場合は 401", async () => {
+    mockGetUser.mockResolvedValue(null);
+
+    const res = await PATCH(patchReq({ url: "https://a.com", title: "A" }), ctx);
+
+    expect(res.status).toBe(401);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("バリデーション失敗（url 無し）は 400", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+
+    const res = await PATCH(patchReq({ title: "A" }), ctx);
+
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("存在しない場合は 404", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockUpdate.mockResolvedValue({ error: "ブックマークが見つかりません" });
+
+    const res = await PATCH(patchReq({ url: "https://a.com", title: "A" }), ctx);
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "ブックマークが見つかりません" });
+  });
+
+  it("他ユーザーのリソースは 403", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockUpdate.mockResolvedValue({ error: "権限がありません" });
+
+    const res = await PATCH(patchReq({ url: "https://a.com", title: "A" }), ctx);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("正常系: 200 で更新リソースを返し lib を呼ぶ", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockUpdate.mockResolvedValue({ bookmark: record as never });
+
+    const res = await PATCH(patchReq({ url: "https://a.com", title: "Updated" }), ctx);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      id: "bm_1",
+      url: "https://a.com",
+      title: "Updated",
+      memo: null,
+      ogImage: null,
+      category: null,
+      createdAt: "2026-01-02T03:04:05.000Z",
+    });
+    expect(mockUpdate).toHaveBeenCalledWith(
+      "user_1",
+      "bm_1",
+      expect.objectContaining({ url: "https://a.com", title: "Updated" }),
+    );
+  });
+});
+
+describe("DELETE /api/bookmarks/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("未認証の場合は 401", async () => {
+    mockGetUser.mockResolvedValue(null);
+
+    const res = await DELETE({} as never, ctx);
+
+    expect(res.status).toBe(401);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("存在しない場合は 404", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockDelete.mockResolvedValue({ error: "ブックマークが見つかりません" });
+
+    const res = await DELETE({} as never, ctx);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("他ユーザーのリソースは 403", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockDelete.mockResolvedValue({ error: "権限がありません" });
+
+    const res = await DELETE({} as never, ctx);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("正常系: 204 で削除し lib を呼ぶ", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockDelete.mockResolvedValue({});
+
+    const res = await DELETE({} as never, ctx);
+
+    expect(res.status).toBe(204);
+    expect(mockDelete).toHaveBeenCalledWith("user_1", "bm_1");
+  });
+});

--- a/src/app/api/bookmarks/[id]/route.ts
+++ b/src/app/api/bookmarks/[id]/route.ts
@@ -3,20 +3,15 @@ import { type NextRequest, NextResponse } from "next/server";
 import { getUserByApiKey } from "@/lib/api-auth";
 import { jsonError, serializeBookmark, statusForError, unauthorized } from "@/lib/api-response";
 import { toBookmarkData, validateBookmarkInput } from "@/lib/bookmark-validation";
-import { createBookmark, deleteBookmarks, getBookmarks } from "@/lib/bookmarks";
+import { deleteBookmark, updateBookmark } from "@/lib/bookmarks";
 
-export async function GET(req: NextRequest) {
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function PATCH(req: NextRequest, { params }: RouteContext) {
   const user = await getUserByApiKey(req);
   if (!user) return unauthorized();
 
-  const bookmarks = await getBookmarks(user.id);
-
-  return NextResponse.json({ bookmarks: bookmarks.map(serializeBookmark) });
-}
-
-export async function POST(req: NextRequest) {
-  const user = await getUserByApiKey(req);
-  if (!user) return unauthorized();
+  const { id } = await params;
 
   const body = await req.json().catch(() => null);
   if (!body || typeof body !== "object") return jsonError("リクエストボディが不正です", 400);
@@ -24,24 +19,20 @@ export async function POST(req: NextRequest) {
   const validationError = validateBookmarkInput(body);
   if (validationError) return jsonError(validationError, 400);
 
-  const result = await createBookmark(user.id, toBookmarkData(body));
+  const result = await updateBookmark(user.id, id, toBookmarkData(body));
   if (result.error) return jsonError(result.error, statusForError(result.error));
-  if (!result.bookmark) return jsonError("作成に失敗しました", 500);
+  if (!result.bookmark) return jsonError("更新に失敗しました", 500);
 
-  return NextResponse.json(serializeBookmark(result.bookmark), { status: 201 });
+  return NextResponse.json(serializeBookmark(result.bookmark));
 }
 
-export async function DELETE(req: NextRequest) {
+export async function DELETE(req: NextRequest, { params }: RouteContext) {
   const user = await getUserByApiKey(req);
   if (!user) return unauthorized();
 
-  const ids = (req.nextUrl.searchParams.get("ids") ?? "")
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
-  if (ids.length === 0) return jsonError("ids は必須です", 400);
+  const { id } = await params;
 
-  const result = await deleteBookmarks(user.id, ids);
+  const result = await deleteBookmark(user.id, id);
   if (result.error) return jsonError(result.error, statusForError(result.error));
 
   return new NextResponse(null, { status: 204 });

--- a/src/app/api/bookmarks/route.test.ts
+++ b/src/app/api/bookmarks/route.test.ts
@@ -106,6 +106,16 @@ describe("POST /api/bookmarks", () => {
     expect(mockCreateBookmark).not.toHaveBeenCalled();
   });
 
+  it("tagId が非文字列の場合は 400（lib に到達させない）", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+
+    const res = await POST(jsonReq({ url: "https://a.com", title: "A", tagId: 123 }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "tagId の形式が不正です" });
+    expect(mockCreateBookmark).not.toHaveBeenCalled();
+  });
+
   it("正常系: 201 で作成リソースを返し lib を呼ぶ", async () => {
     mockGetUser.mockResolvedValue({ id: "user_1" });
     mockCreateBookmark.mockResolvedValue({ bookmark: record as never });

--- a/src/app/api/bookmarks/route.test.ts
+++ b/src/app/api/bookmarks/route.test.ts
@@ -1,18 +1,42 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { GET } from "./route";
+import { DELETE, GET, POST } from "./route";
 
 vi.mock("@/lib/api-auth", () => ({ getUserByApiKey: vi.fn() }));
-vi.mock("@/lib/bookmarks", () => ({ getBookmarks: vi.fn() }));
+vi.mock("@/lib/bookmarks", () => ({
+  getBookmarks: vi.fn(),
+  createBookmark: vi.fn(),
+  deleteBookmarks: vi.fn(),
+}));
 
 vi.stubEnv("DATABASE_URL", "postgresql://test");
 
 import { getUserByApiKey } from "@/lib/api-auth";
-import { getBookmarks } from "@/lib/bookmarks";
+import { createBookmark, deleteBookmarks, getBookmarks } from "@/lib/bookmarks";
 
 const mockGetUser = vi.mocked(getUserByApiKey);
 const mockGetBookmarks = vi.mocked(getBookmarks);
+const mockCreateBookmark = vi.mocked(createBookmark);
+const mockDeleteBookmarks = vi.mocked(deleteBookmarks);
+
+const record = {
+  id: "bm_1",
+  url: "https://a.com",
+  title: "A",
+  memo: "memo",
+  ogImage: null,
+  createdAt: new Date("2026-01-02T03:04:05.000Z"),
+  tag: { id: "t1", name: "Cat" },
+};
+
+function jsonReq(body: unknown) {
+  return { json: async () => body } as never;
+}
+
+function deleteReq(query: string) {
+  return { nextUrl: { searchParams: new URLSearchParams(query) } } as never;
+}
 
 describe("GET /api/bookmarks", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -29,18 +53,7 @@ describe("GET /api/bookmarks", () => {
 
   it("認証成功時は未削除ブックマークを JSON で返す", async () => {
     mockGetUser.mockResolvedValue({ id: "user_1" });
-    const createdAt = new Date("2026-01-02T03:04:05.000Z");
-    mockGetBookmarks.mockResolvedValue([
-      {
-        id: "bm_1",
-        url: "https://a.com",
-        title: "A",
-        memo: "memo",
-        ogImage: "img",
-        createdAt,
-        tag: { id: "t1", name: "Cat" },
-      },
-    ] as never);
+    mockGetBookmarks.mockResolvedValue([record] as never);
 
     const res = await GET({} as never);
 
@@ -52,32 +65,98 @@ describe("GET /api/bookmarks", () => {
           url: "https://a.com",
           title: "A",
           memo: "memo",
-          ogImage: "img",
+          ogImage: null,
           category: { id: "t1", name: "Cat" },
-          createdAt: createdAt.toISOString(),
+          createdAt: "2026-01-02T03:04:05.000Z",
         },
       ],
     });
     expect(mockGetBookmarks).toHaveBeenCalledWith("user_1");
   });
+});
 
-  it("カテゴリ未設定は category: null で返す", async () => {
+describe("POST /api/bookmarks", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("未認証の場合は 401", async () => {
+    mockGetUser.mockResolvedValue(null);
+
+    const res = await POST(jsonReq({ url: "https://a.com", title: "A" }));
+
+    expect(res.status).toBe(401);
+    expect(mockCreateBookmark).not.toHaveBeenCalled();
+  });
+
+  it("ボディが不正（非オブジェクト）な場合は 400", async () => {
     mockGetUser.mockResolvedValue({ id: "user_1" });
-    mockGetBookmarks.mockResolvedValue([
-      {
-        id: "bm_2",
-        url: "https://b.com",
-        title: "B",
-        memo: null,
-        ogImage: null,
-        createdAt: new Date(),
-        tag: null,
-      },
-    ] as never);
 
-    const res = await GET({} as never);
-    const json = await res.json();
+    const res = await POST({ json: async () => null } as never);
 
-    expect(json.bookmarks[0].category).toBeNull();
+    expect(res.status).toBe(400);
+    expect(mockCreateBookmark).not.toHaveBeenCalled();
+  });
+
+  it("バリデーション失敗（title 無し）は 400", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+
+    const res = await POST(jsonReq({ url: "https://a.com" }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "title は必須です" });
+    expect(mockCreateBookmark).not.toHaveBeenCalled();
+  });
+
+  it("正常系: 201 で作成リソースを返し lib を呼ぶ", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockCreateBookmark.mockResolvedValue({ bookmark: record as never });
+
+    const res = await POST(jsonReq({ url: "https://a.com", title: "A", memo: "memo" }));
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({
+      id: "bm_1",
+      url: "https://a.com",
+      title: "A",
+      memo: "memo",
+      ogImage: null,
+      category: { id: "t1", name: "Cat" },
+      createdAt: "2026-01-02T03:04:05.000Z",
+    });
+    expect(mockCreateBookmark).toHaveBeenCalledWith(
+      "user_1",
+      expect.objectContaining({ url: "https://a.com", title: "A", memo: "memo" }),
+    );
+  });
+});
+
+describe("DELETE /api/bookmarks", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("未認証の場合は 401", async () => {
+    mockGetUser.mockResolvedValue(null);
+
+    const res = await DELETE(deleteReq("ids=bm_1"));
+
+    expect(res.status).toBe(401);
+    expect(mockDeleteBookmarks).not.toHaveBeenCalled();
+  });
+
+  it("ids 未指定は 400", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+
+    const res = await DELETE(deleteReq(""));
+
+    expect(res.status).toBe(400);
+    expect(mockDeleteBookmarks).not.toHaveBeenCalled();
+  });
+
+  it("正常系: 204 でソフトデリートし ids を渡す", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockDeleteBookmarks.mockResolvedValue({});
+
+    const res = await DELETE(deleteReq("ids=bm_1,bm_2"));
+
+    expect(res.status).toBe(204);
+    expect(mockDeleteBookmarks).toHaveBeenCalledWith("user_1", ["bm_1", "bm_2"]);
   });
 });

--- a/src/lib/api-response.test.ts
+++ b/src/lib/api-response.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { jsonError, serializeBookmark, statusForError, unauthorized } from "./api-response";
+
+const base = {
+  id: "bm_1",
+  url: "https://example.com",
+  title: "Example",
+  memo: "メモ",
+  ogImage: "https://example.com/og.png",
+  createdAt: new Date("2026-01-02T03:04:05.000Z"),
+};
+
+describe("serializeBookmark", () => {
+  it("正常系: tag を category に変換し createdAt を ISO 文字列で返す", () => {
+    const result = serializeBookmark({ ...base, tag: { id: "t1", name: "Cat" } });
+
+    expect(result).toEqual({
+      id: "bm_1",
+      url: "https://example.com",
+      title: "Example",
+      memo: "メモ",
+      ogImage: "https://example.com/og.png",
+      category: { id: "t1", name: "Cat" },
+      createdAt: "2026-01-02T03:04:05.000Z",
+    });
+  });
+
+  it("tag が null の場合は category: null", () => {
+    const result = serializeBookmark({ ...base, memo: null, ogImage: null, tag: null });
+
+    expect(result.category).toBeNull();
+    expect(result.memo).toBeNull();
+    expect(result.ogImage).toBeNull();
+  });
+});
+
+describe("statusForError", () => {
+  it("「権限がありません」は 403", () => {
+    expect(statusForError("権限がありません")).toBe(403);
+  });
+
+  it("「見つかりません」を含む場合は 404", () => {
+    expect(statusForError("ブックマークが見つかりません")).toBe(404);
+    expect(statusForError("カテゴリが見つかりません")).toBe(404);
+  });
+
+  it("それ以外は 400", () => {
+    expect(statusForError("タグ名が不正です")).toBe(400);
+  });
+});
+
+describe("jsonError / unauthorized", () => {
+  it("jsonError は指定 status と error ボディを返す", async () => {
+    const res = jsonError("だめ", 400);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "だめ" });
+  });
+
+  it("unauthorized は 401 / Unauthorized", async () => {
+    const res = unauthorized();
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Unauthorized" });
+  });
+});

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+type SerializableBookmark = {
+  id: string;
+  url: string;
+  title: string;
+  memo: string | null;
+  ogImage: string | null;
+  createdAt: Date;
+  tag: { id: string; name: string } | null;
+};
+
+/** ブックマークを外部 API レスポンス形式（camelCase / createdAt は ISO / category）に整形する。 */
+export function serializeBookmark(b: SerializableBookmark) {
+  return {
+    id: b.id,
+    url: b.url,
+    title: b.title,
+    memo: b.memo,
+    ogImage: b.ogImage,
+    category: b.tag ? { id: b.tag.id, name: b.tag.name } : null,
+    createdAt: b.createdAt.toISOString(),
+  };
+}
+
+/** lib が返すエラーメッセージを HTTP ステータスにマッピングする。 */
+export function statusForError(message: string): number {
+  if (message.includes("権限がありません")) return 403;
+  if (message.includes("見つかりません")) return 404;
+  return 400;
+}
+
+/** `{ error }` ボディ付きのエラーレスポンスを返す。 */
+export function jsonError(message: string, status: number) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+/** 認証失敗（401）レスポンス。 */
+export function unauthorized() {
+  return jsonError("Unauthorized", 401);
+}

--- a/src/lib/bookmark-validation.test.ts
+++ b/src/lib/bookmark-validation.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { toBookmarkData, validateBookmarkInput } from "./bookmark-validation";
+
+describe("validateBookmarkInput", () => {
+  it("正常系: url と title が揃っていれば null", () => {
+    expect(validateBookmarkInput({ url: "https://example.com", title: "Example" })).toBeNull();
+    expect(validateBookmarkInput({ url: "http://example.com", title: "x" })).toBeNull();
+  });
+
+  it("url が無い・空・非文字列は url エラー", () => {
+    expect(validateBookmarkInput({ title: "x" })).toBe("url は必須です");
+    expect(validateBookmarkInput({ url: "  ", title: "x" })).toBe("url は必須です");
+    expect(validateBookmarkInput({ url: 123, title: "x" })).toBe("url は必須です");
+  });
+
+  it("url の形式が不正なら形式エラー", () => {
+    expect(validateBookmarkInput({ url: "not a url", title: "x" })).toBe("url の形式が不正です");
+  });
+
+  it("http/https 以外のスキームはスキームエラー", () => {
+    expect(validateBookmarkInput({ url: "ftp://example.com", title: "x" })).toBe(
+      "url は http または https のみ対応しています",
+    );
+    expect(validateBookmarkInput({ url: "javascript:alert(1)", title: "x" })).toBe(
+      "url は http または https のみ対応しています",
+    );
+  });
+
+  it("title が無い・空・非文字列は title エラー", () => {
+    expect(validateBookmarkInput({ url: "https://example.com" })).toBe("title は必須です");
+    expect(validateBookmarkInput({ url: "https://example.com", title: "  " })).toBe(
+      "title は必須です",
+    );
+    expect(validateBookmarkInput({ url: "https://example.com", title: 1 })).toBe(
+      "title は必須です",
+    );
+  });
+});
+
+describe("toBookmarkData", () => {
+  it("正常系: 各フィールドを BookmarkData に変換する", () => {
+    const result = toBookmarkData({
+      url: "https://example.com",
+      title: "Example",
+      memo: "メモ",
+      ogImage: "https://example.com/og.png",
+      tagId: "tag_1",
+      hideOgImage: true,
+    });
+
+    expect(result).toEqual({
+      url: "https://example.com",
+      title: "Example",
+      memo: "メモ",
+      ogImage: "https://example.com/og.png",
+      tagId: "tag_1",
+      hideOgImage: true,
+    });
+  });
+
+  it("省略されたフィールドは undefined / memo は空文字にフォールバック", () => {
+    const result = toBookmarkData({ url: "https://example.com", title: "x" });
+
+    expect(result).toEqual({
+      url: "https://example.com",
+      title: "x",
+      memo: "",
+      ogImage: undefined,
+      tagId: undefined,
+      hideOgImage: undefined,
+    });
+  });
+
+  it("tagId に null を明示した場合は null（未分類化）を保持する", () => {
+    const result = toBookmarkData({ url: "https://example.com", title: "x", tagId: null });
+
+    expect(result.tagId).toBeNull();
+  });
+});

--- a/src/lib/bookmark-validation.test.ts
+++ b/src/lib/bookmark-validation.test.ts
@@ -37,6 +37,25 @@ describe("validateBookmarkInput", () => {
       "title は必須です",
     );
   });
+
+  it("tagId が string / null / 省略なら通過する", () => {
+    expect(
+      validateBookmarkInput({ url: "https://example.com", title: "x", tagId: "tag_1" }),
+    ).toBeNull();
+    expect(
+      validateBookmarkInput({ url: "https://example.com", title: "x", tagId: null }),
+    ).toBeNull();
+    expect(validateBookmarkInput({ url: "https://example.com", title: "x" })).toBeNull();
+  });
+
+  it("tagId が非文字列（数値・配列・オブジェクト）は 400 相当のエラー", () => {
+    const msg = "tagId の形式が不正です";
+    expect(validateBookmarkInput({ url: "https://example.com", title: "x", tagId: 123 })).toBe(msg);
+    expect(validateBookmarkInput({ url: "https://example.com", title: "x", tagId: ["a"] })).toBe(
+      msg,
+    );
+    expect(validateBookmarkInput({ url: "https://example.com", title: "x", tagId: {} })).toBe(msg);
+  });
 });
 
 describe("toBookmarkData", () => {
@@ -60,17 +79,23 @@ describe("toBookmarkData", () => {
     });
   });
 
-  it("省略されたフィールドは undefined / memo は空文字にフォールバック", () => {
+  it("省略されたフィールドはすべて undefined（更新しない意図）", () => {
     const result = toBookmarkData({ url: "https://example.com", title: "x" });
 
     expect(result).toEqual({
       url: "https://example.com",
       title: "x",
-      memo: "",
+      memo: undefined,
       ogImage: undefined,
       tagId: undefined,
       hideOgImage: undefined,
     });
+  });
+
+  it("memo に空文字を明示した場合は空文字（＝クリア）を保持する", () => {
+    const result = toBookmarkData({ url: "https://example.com", title: "x", memo: "" });
+
+    expect(result.memo).toBe("");
   });
 
   it("tagId に null を明示した場合は null（未分類化）を保持する", () => {

--- a/src/lib/bookmark-validation.ts
+++ b/src/lib/bookmark-validation.ts
@@ -5,7 +5,11 @@ import type { BookmarkData } from "@/lib/bookmarks";
  * UI 側で行っている検証と同等の内容をサーバー側でも行う。
  * 問題なければ null、不正なら日本語のエラーメッセージを返す。
  */
-export function validateBookmarkInput(body: { url?: unknown; title?: unknown }): string | null {
+export function validateBookmarkInput(body: {
+  url?: unknown;
+  title?: unknown;
+  tagId?: unknown;
+}): string | null {
   if (typeof body.url !== "string" || body.url.trim() === "") {
     return "url は必須です";
   }
@@ -24,18 +28,25 @@ export function validateBookmarkInput(body: { url?: unknown; title?: unknown }):
     return "title は必須です";
   }
 
+  // tagId は string（カテゴリ ID）または null（未分類）のみ許可。
+  // 非文字列を許すと Prisma に渡って実行時例外→500 になるため 400 で弾く。
+  if ("tagId" in body && body.tagId !== null && typeof body.tagId !== "string") {
+    return "tagId の形式が不正です";
+  }
+
   return null;
 }
 
 /**
  * 検証済みリクエストボディを lib の BookmarkData に変換する。
- * `tagId` / `ogImage` はキーの有無で「更新しない(undefined)」と「クリアする(null/"")」を区別する。
+ * 各フィールドはキーの有無で「更新しない(undefined)」と「クリアする(null/"")」を区別する
+ * （`memo`/`ogImage` は空文字でクリア、`tagId` は null で未分類化）。
  */
 export function toBookmarkData(body: Record<string, unknown>): BookmarkData {
   return {
     url: body.url as string,
     title: body.title as string,
-    memo: typeof body.memo === "string" ? body.memo : "",
+    memo: "memo" in body ? (typeof body.memo === "string" ? body.memo : "") : undefined,
     ogImage: typeof body.ogImage === "string" ? body.ogImage : undefined,
     tagId: "tagId" in body ? (body.tagId as string | null) : undefined,
     hideOgImage: typeof body.hideOgImage === "boolean" ? body.hideOgImage : undefined,

--- a/src/lib/bookmark-validation.ts
+++ b/src/lib/bookmark-validation.ts
@@ -1,0 +1,43 @@
+import type { BookmarkData } from "@/lib/bookmarks";
+
+/**
+ * 外部 API のリクエストボディを検証する。信頼できるクライアントがいないため、
+ * UI 側で行っている検証と同等の内容をサーバー側でも行う。
+ * 問題なければ null、不正なら日本語のエラーメッセージを返す。
+ */
+export function validateBookmarkInput(body: { url?: unknown; title?: unknown }): string | null {
+  if (typeof body.url !== "string" || body.url.trim() === "") {
+    return "url は必須です";
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(body.url);
+  } catch {
+    return "url の形式が不正です";
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return "url は http または https のみ対応しています";
+  }
+
+  if (typeof body.title !== "string" || body.title.trim() === "") {
+    return "title は必須です";
+  }
+
+  return null;
+}
+
+/**
+ * 検証済みリクエストボディを lib の BookmarkData に変換する。
+ * `tagId` / `ogImage` はキーの有無で「更新しない(undefined)」と「クリアする(null/"")」を区別する。
+ */
+export function toBookmarkData(body: Record<string, unknown>): BookmarkData {
+  return {
+    url: body.url as string,
+    title: body.title as string,
+    memo: typeof body.memo === "string" ? body.memo : "",
+    ogImage: typeof body.ogImage === "string" ? body.ogImage : undefined,
+    tagId: "tagId" in body ? (body.tagId as string | null) : undefined,
+    hideOgImage: typeof body.hideOgImage === "boolean" ? body.hideOgImage : undefined,
+  };
+}

--- a/src/lib/bookmarks.test.ts
+++ b/src/lib/bookmarks.test.ts
@@ -115,20 +115,22 @@ describe("getDeletedBookmarks", () => {
 describe("createBookmark", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: ブックマークを作成して {} を返す", async () => {
+  it("正常系: ブックマークを作成して作成レコードを返す", async () => {
     mockBookmarkAggregate.mockResolvedValue({ _max: { sortOrder: 3 } } as never);
     mockBookmarkCreate.mockResolvedValue(bookmark);
 
     const result = await createBookmark(userId, bookmarkData);
 
-    expect(result).toEqual({});
+    expect(result).toEqual({ bookmark });
     expect(mockBookmarkAggregate).toHaveBeenCalledWith({
       where: { userId },
       _max: { sortOrder: true },
     });
-    expect(mockBookmarkCreate).toHaveBeenCalledWith({
-      data: expect.objectContaining({ userId, url: "https://example.com", sortOrder: 4 }),
-    });
+    expect(mockBookmarkCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ userId, url: "https://example.com", sortOrder: 4 }),
+      }),
+    );
   });
 
   it("ブックマークが0件のとき sortOrder が 0 になる", async () => {
@@ -137,9 +139,9 @@ describe("createBookmark", () => {
 
     await createBookmark(userId, bookmarkData);
 
-    expect(mockBookmarkCreate).toHaveBeenCalledWith({
-      data: expect.objectContaining({ sortOrder: 0 }),
-    });
+    expect(mockBookmarkCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ sortOrder: 0 }) }),
+    );
   });
 
   it("tagId を指定すると自ユーザーのタグか検証してセットする", async () => {
@@ -153,9 +155,9 @@ describe("createBookmark", () => {
       where: { id: "tag_1", userId },
       select: { id: true },
     });
-    expect(mockBookmarkCreate).toHaveBeenCalledWith({
-      data: expect.objectContaining({ tagId: "tag_1" }),
-    });
+    expect(mockBookmarkCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ tagId: "tag_1" }) }),
+    );
   });
 
   it("他ユーザーの tagId は null にフォールバックする", async () => {
@@ -165,22 +167,23 @@ describe("createBookmark", () => {
 
     await createBookmark(userId, { ...bookmarkData, tagId: "tag_other" });
 
-    expect(mockBookmarkCreate).toHaveBeenCalledWith({
-      data: expect.objectContaining({ tagId: null }),
-    });
+    expect(mockBookmarkCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ tagId: null }) }),
+    );
   });
 });
 
 describe("updateBookmark", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: ブックマークを更新して {} を返す", async () => {
+  it("正常系: ブックマークを更新して更新レコードを返す", async () => {
     mockBookmarkFindUnique.mockResolvedValue(bookmark as never);
-    mockBookmarkUpdate.mockResolvedValue({ ...bookmark, title: "Updated" });
+    const updated = { ...bookmark, title: "Updated" };
+    mockBookmarkUpdate.mockResolvedValue(updated);
 
     const result = await updateBookmark(userId, "bm_1", { ...bookmarkData, title: "Updated" });
 
-    expect(result).toEqual({});
+    expect(result).toEqual({ bookmark: updated });
     expect(mockBookmarkUpdate).toHaveBeenCalled();
   });
 

--- a/src/lib/bookmarks.test.ts
+++ b/src/lib/bookmarks.test.ts
@@ -240,6 +240,16 @@ describe("updateBookmark", () => {
     const callArg = mockBookmarkUpdate.mock.calls[0][0];
     expect(callArg.data).not.toHaveProperty("hideOgImage");
   });
+
+  it("memo が undefined の場合は update データに含めない（既存値を保持）", async () => {
+    mockBookmarkFindUnique.mockResolvedValue(bookmark as never);
+    mockBookmarkUpdate.mockResolvedValue(bookmark);
+
+    await updateBookmark(userId, "bm_1", { url: "https://example.com", title: "x" });
+
+    const callArg = mockBookmarkUpdate.mock.calls[0][0];
+    expect(callArg.data).not.toHaveProperty("memo");
+  });
 });
 
 describe("moveBookmark", () => {

--- a/src/lib/bookmarks.ts
+++ b/src/lib/bookmarks.ts
@@ -5,7 +5,7 @@ import { prisma } from "@/lib/prisma";
 export type BookmarkData = {
   url: string;
   title: string;
-  memo: string;
+  memo?: string;
   ogImage?: string;
   tagId?: string | null;
   hideOgImage?: boolean;
@@ -109,7 +109,7 @@ export async function updateBookmark(
     data: {
       url: data.url,
       title: data.title,
-      memo: data.memo || null,
+      ...(data.memo !== undefined ? { memo: data.memo || null } : {}),
       ...(data.ogImage !== undefined ? { ogImage: data.ogImage ?? null } : {}),
       ...(data.hideOgImage !== undefined ? { hideOgImage: data.hideOgImage } : {}),
       ...(validTagId !== undefined ? { tagId: validTagId } : {}),

--- a/src/lib/bookmarks.ts
+++ b/src/lib/bookmarks.ts
@@ -1,3 +1,5 @@
+import type { Prisma } from "@prisma/client";
+
 import { prisma } from "@/lib/prisma";
 
 export type BookmarkData = {
@@ -8,6 +10,10 @@ export type BookmarkData = {
   tagId?: string | null;
   hideOgImage?: boolean;
 };
+
+export type BookmarkWithTag = Prisma.BookmarkGetPayload<{
+  include: { tag: { select: { id: true; name: true } } };
+}>;
 
 export async function getBookmarks(userId: string, query?: string) {
   const where = {
@@ -44,7 +50,7 @@ export async function getDeletedBookmarks(userId: string) {
 export async function createBookmark(
   userId: string,
   data: BookmarkData,
-): Promise<{ error?: string }> {
+): Promise<{ bookmark?: BookmarkWithTag; error?: string }> {
   const agg = await prisma.bookmark.aggregate({
     where: { userId },
     _max: { sortOrder: true },
@@ -60,7 +66,7 @@ export async function createBookmark(
     if (tag) validTagId = tag.id;
   }
 
-  await prisma.bookmark.create({
+  const bookmark = await prisma.bookmark.create({
     data: {
       userId,
       url: data.url,
@@ -70,16 +76,17 @@ export async function createBookmark(
       sortOrder,
       tagId: validTagId,
     },
+    include: { tag: { select: { id: true, name: true } } },
   });
 
-  return {};
+  return { bookmark };
 }
 
 export async function updateBookmark(
   userId: string,
   id: string,
   data: BookmarkData,
-): Promise<{ error?: string }> {
+): Promise<{ bookmark?: BookmarkWithTag; error?: string }> {
   const bookmark = await prisma.bookmark.findUnique({ where: { id } });
   if (!bookmark) return { error: "ブックマークが見つかりません" };
   if (bookmark.userId !== userId) return { error: "権限がありません" };
@@ -97,7 +104,7 @@ export async function updateBookmark(
     }
   }
 
-  await prisma.bookmark.update({
+  const updated = await prisma.bookmark.update({
     where: { id },
     data: {
       url: data.url,
@@ -107,9 +114,10 @@ export async function updateBookmark(
       ...(data.hideOgImage !== undefined ? { hideOgImage: data.hideOgImage } : {}),
       ...(validTagId !== undefined ? { tagId: validTagId } : {}),
     },
+    include: { tag: { select: { id: true, name: true } } },
   });
 
-  return {};
+  return { bookmark: updated };
 }
 
 export async function moveBookmark(


### PR DESCRIPTION
## 概要

ブックマークの書き込み操作を **API キー認証の REST API** として公開する（T108 / エピック #253）。業務ロジックは `src/lib/` に集約済みのため、`src/app/api/` に薄い route ハンドラを追加し、UI 用の Server Actions と同じ lib 関数を共有する。

Closes #252

## 追加エンドポイント

| メソッド | パス | 動作 |
|---|---|---|
| `POST` | `/api/bookmarks` | 作成 → 201 + 作成リソース |
| `DELETE` | `/api/bookmarks?ids=a,b` | 一括ソフトデリート → 204 |
| `PATCH` | `/api/bookmarks/:id` | 更新（カテゴリ変更含む）→ 200 + 更新リソース |
| `DELETE` | `/api/bookmarks/:id` | ソフトデリート → 204 |

認証は既存 `getUserByApiKey`（`Authorization: Bearer`）を再利用。

## 主な変更

- `src/lib/api-response.ts`（新）: レスポンス整形 `serializeBookmark`（既存 GET も共通化）＋ lib エラー→HTTP status マッピング
- `src/lib/bookmark-validation.ts`（新）: サーバー側バリデータ `validateBookmarkInput`（url 必須・http/https・title 必須）＋ ボディ→`BookmarkData` 変換 `toBookmarkData`
- `src/lib/bookmarks.ts`: `createBookmark`/`updateBookmark` を作成/更新レコード（tag 込み）返却に拡張。**Server Actions は無変更**（型互換）
- `src/app/api/bookmarks/route.ts` ＋ `[id]/route.ts`: ルートハンドラ
- 各ユニットテスト、`docs/api.md` 更新

## レビュアーへの補足（設計判断）

- **サーバー側バリデーションを新設**: 外部 API は信頼できるクライアントがいないため、UI ではクライアント側のみだった url/title 検証をサーバーでも行う。
- **PATCH は `sortOrder` を扱わない**: カテゴリ変更は `tagId` で対応し、並び順変更は reorder API（T109）に委譲。外部 API として素直な形に整理（api.md に明記）。
- **ベースブランチは `feature/rest-api`**（統合ブランチ）。全子 Issue 完了後に `feature/rest-api` → `develop` の PR を出す。

## 確認

- ユニットテスト 174 件 green（新規 44 件）／ biome / 型チェック問題なし
- 開発環境で実機動作確認（全 16 項目 PASS）。エビデンスは #252 のコメント参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)