### PR TITLE
feat: ブックマーク並び替え・ゴミ箱 REST API を追加 (T109)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -44,10 +44,14 @@
 | `GET` | `/api/bookmarks` | ブックマーク一覧を取得 |
 | `POST` | `/api/bookmarks` | ブックマークを作成 |
 | `DELETE` | `/api/bookmarks?ids=a,b,c` | 複数ブックマークを一括削除（ゴミ箱へ） |
-| `PATCH` | `/api/bookmarks/:id` | ブックマークを更新（カテゴリ移動・並び順変更を含む） |
+| `POST` | `/api/bookmarks/reorder` | 並び順を一括更新 |
+| `GET` | `/api/bookmarks/trash` | ゴミ箱（削除済み）一覧を取得 |
+| `DELETE` | `/api/bookmarks/trash` | ゴミ箱を空にする（完全削除） |
+| `PATCH` | `/api/bookmarks/:id` | ブックマークを更新（カテゴリ移動を含む） |
 | `DELETE` | `/api/bookmarks/:id` | ブックマークを削除（ゴミ箱へ） |
+| `POST` | `/api/bookmarks/:id/restore` | ゴミ箱から復元 |
 
-> 削除はソフトデリート（ゴミ箱へ移動）。ゴミ箱の一覧・復元・完全削除、並び替え、カテゴリ API は別 Issue で追加予定。
+> 削除はソフトデリート（ゴミ箱へ移動）。カテゴリ API は別 Issue で追加予定。
 
 ---
 
@@ -157,3 +161,71 @@ curl -s -X DELETE -H "Authorization: Bearer ${LH_API_KEY}" \
 ### レスポンス（204）
 
 ボディなし。
+
+---
+
+## `POST /api/bookmarks/reorder` — 並び替え
+
+`ids` の並び順どおりに `sortOrder` を一括更新する。自ユーザー所有分のみ。
+
+### リクエストボディ
+
+| フィールド | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `ids` | string[] | ✅ | 並べたい順のブックマーク ID 配列（文字列以外・空配列は 400） |
+
+```bash
+curl -s -X POST -H "Authorization: Bearer ${LH_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"ids":["clxxxx","clyyyy","clzzzz"]}' \
+  http://localhost:3000/api/bookmarks/reorder
+```
+
+### レスポンス（200）
+
+ボディなし。指定 ID に他ユーザーのものが含まれる場合は `403`。
+
+---
+
+## `GET /api/bookmarks/trash` — ゴミ箱一覧
+
+削除済み（ソフトデリート）のブックマークを削除日時の降順で返す。形式は一覧取得と同じ。
+
+```bash
+curl -s -H "Authorization: Bearer ${LH_API_KEY}" \
+  http://localhost:3000/api/bookmarks/trash | jq
+```
+
+### レスポンス（200）
+
+`GET /api/bookmarks` と同じ `{ "bookmarks": [ ... ] }` 形式。
+
+---
+
+## `DELETE /api/bookmarks/trash` — ゴミ箱を空にする
+
+ゴミ箱内のブックマークを**完全削除**する（物理削除・不可逆）。
+
+```bash
+curl -s -X DELETE -H "Authorization: Bearer ${LH_API_KEY}" \
+  http://localhost:3000/api/bookmarks/trash
+```
+
+### レスポンス（204）
+
+ボディなし。
+
+---
+
+## `POST /api/bookmarks/:id/restore` — 復元
+
+ゴミ箱内のブックマークを元のカテゴリに復元する（`deletedAt` を解除）。
+
+```bash
+curl -s -X POST -H "Authorization: Bearer ${LH_API_KEY}" \
+  http://localhost:3000/api/bookmarks/clxxxx/restore | jq
+```
+
+### レスポンス（200）
+
+復元後のブックマーク（共通形式）を返す。未存在は `404`、他ユーザーのものは `403`。

--- a/src/app/api/bookmarks/[id]/restore/route.test.ts
+++ b/src/app/api/bookmarks/[id]/restore/route.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST } from "./route";
+
+vi.mock("@/lib/api-auth", () => ({ getUserByApiKey: vi.fn() }));
+vi.mock("@/lib/bookmarks", () => ({ restoreBookmark: vi.fn() }));
+
+vi.stubEnv("DATABASE_URL", "postgresql://test");
+
+import { getUserByApiKey } from "@/lib/api-auth";
+import { restoreBookmark } from "@/lib/bookmarks";
+
+const mockGetUser = vi.mocked(getUserByApiKey);
+const mockRestore = vi.mocked(restoreBookmark);
+
+const record = {
+  id: "bm_1",
+  url: "https://a.com",
+  title: "A",
+  memo: null,
+  ogImage: null,
+  createdAt: new Date("2026-01-02T03:04:05.000Z"),
+  tag: { id: "t1", name: "Cat" },
+};
+
+const ctx = { params: Promise.resolve({ id: "bm_1" }) };
+
+describe("POST /api/bookmarks/:id/restore", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("未認証の場合は 401", async () => {
+    mockGetUser.mockResolvedValue(null);
+
+    const res = await POST({} as never, ctx);
+
+    expect(res.status).toBe(401);
+    expect(mockRestore).not.toHaveBeenCalled();
+  });
+
+  it("存在しない場合は 404", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockRestore.mockResolvedValue({ error: "ブックマークが見つかりません" });
+
+    const res = await POST({} as never, ctx);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("他ユーザーのリソースは 403", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockRestore.mockResolvedValue({ error: "権限がありません" });
+
+    const res = await POST({} as never, ctx);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("正常系: 200 で復元リソースを返し lib を呼ぶ", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockRestore.mockResolvedValue({ bookmark: record as never });
+
+    const res = await POST({} as never, ctx);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      id: "bm_1",
+      url: "https://a.com",
+      title: "A",
+      memo: null,
+      ogImage: null,
+      category: { id: "t1", name: "Cat" },
+      createdAt: "2026-01-02T03:04:05.000Z",
+    });
+    expect(mockRestore).toHaveBeenCalledWith("user_1", "bm_1");
+  });
+});

--- a/src/app/api/bookmarks/[id]/restore/route.ts
+++ b/src/app/api/bookmarks/[id]/restore/route.ts
@@ -1,0 +1,20 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { getUserByApiKey } from "@/lib/api-auth";
+import { jsonError, serializeBookmark, statusForError, unauthorized } from "@/lib/api-response";
+import { restoreBookmark } from "@/lib/bookmarks";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function POST(req: NextRequest, { params }: RouteContext) {
+  const user = await getUserByApiKey(req);
+  if (!user) return unauthorized();
+
+  const { id } = await params;
+
+  const result = await restoreBookmark(user.id, id);
+  if (result.error) return jsonError(result.error, statusForError(result.error));
+  if (!result.bookmark) return jsonError("復元に失敗しました", 500);
+
+  return NextResponse.json(serializeBookmark(result.bookmark));
+}

--- a/src/app/api/bookmarks/reorder/route.test.ts
+++ b/src/app/api/bookmarks/reorder/route.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST } from "./route";
+
+vi.mock("@/lib/api-auth", () => ({ getUserByApiKey: vi.fn() }));
+vi.mock("@/lib/bookmarks", () => ({ reorderBookmarks: vi.fn() }));
+
+vi.stubEnv("DATABASE_URL", "postgresql://test");
+
+import { getUserByApiKey } from "@/lib/api-auth";
+import { reorderBookmarks } from "@/lib/bookmarks";
+
+const mockGetUser = vi.mocked(getUserByApiKey);
+const mockReorder = vi.mocked(reorderBookmarks);
+
+function jsonReq(body: unknown) {
+  return { json: async () => body } as never;
+}
+
+describe("POST /api/bookmarks/reorder", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("未認証の場合は 401", async () => {
+    mockGetUser.mockResolvedValue(null);
+
+    const res = await POST(jsonReq({ ids: ["a", "b"] }));
+
+    expect(res.status).toBe(401);
+    expect(mockReorder).not.toHaveBeenCalled();
+  });
+
+  it("ids が配列でない場合は 400", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+
+    const res = await POST(jsonReq({ ids: "a,b" }));
+
+    expect(res.status).toBe(400);
+    expect(mockReorder).not.toHaveBeenCalled();
+  });
+
+  it("ids に非文字列が含まれる場合は 400", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+
+    const res = await POST(jsonReq({ ids: ["a", 1] }));
+
+    expect(res.status).toBe(400);
+    expect(mockReorder).not.toHaveBeenCalled();
+  });
+
+  it("ids が空配列の場合は 400", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+
+    const res = await POST(jsonReq({ ids: [] }));
+
+    expect(res.status).toBe(400);
+    expect(mockReorder).not.toHaveBeenCalled();
+  });
+
+  it("他ユーザーの id 混入は 403", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockReorder.mockResolvedValue({ error: "権限がありません" });
+
+    const res = await POST(jsonReq({ ids: ["a", "b"] }));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("正常系: 200 で並び替えし ids を渡す", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockReorder.mockResolvedValue({});
+
+    const res = await POST(jsonReq({ ids: ["a", "b"] }));
+
+    expect(res.status).toBe(200);
+    expect(mockReorder).toHaveBeenCalledWith("user_1", ["a", "b"]);
+  });
+});

--- a/src/app/api/bookmarks/reorder/route.ts
+++ b/src/app/api/bookmarks/reorder/route.ts
@@ -1,0 +1,22 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { getUserByApiKey } from "@/lib/api-auth";
+import { jsonError, statusForError, unauthorized } from "@/lib/api-response";
+import { reorderBookmarks } from "@/lib/bookmarks";
+
+export async function POST(req: NextRequest) {
+  const user = await getUserByApiKey(req);
+  if (!user) return unauthorized();
+
+  const body = await req.json().catch(() => null);
+  const ids = body?.ids;
+  if (!Array.isArray(ids) || ids.some((id) => typeof id !== "string")) {
+    return jsonError("ids は文字列の配列で指定してください", 400);
+  }
+  if (ids.length === 0) return jsonError("ids は必須です", 400);
+
+  const result = await reorderBookmarks(user.id, ids);
+  if (result.error) return jsonError(result.error, statusForError(result.error));
+
+  return new NextResponse(null, { status: 200 });
+}

--- a/src/app/api/bookmarks/trash/route.test.ts
+++ b/src/app/api/bookmarks/trash/route.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DELETE, GET } from "./route";
+
+vi.mock("@/lib/api-auth", () => ({ getUserByApiKey: vi.fn() }));
+vi.mock("@/lib/bookmarks", () => ({
+  getDeletedBookmarks: vi.fn(),
+  emptyTrash: vi.fn(),
+}));
+
+vi.stubEnv("DATABASE_URL", "postgresql://test");
+
+import { getUserByApiKey } from "@/lib/api-auth";
+import { emptyTrash, getDeletedBookmarks } from "@/lib/bookmarks";
+
+const mockGetUser = vi.mocked(getUserByApiKey);
+const mockGetDeleted = vi.mocked(getDeletedBookmarks);
+const mockEmptyTrash = vi.mocked(emptyTrash);
+
+const record = {
+  id: "bm_1",
+  url: "https://a.com",
+  title: "A",
+  memo: null,
+  ogImage: null,
+  createdAt: new Date("2026-01-02T03:04:05.000Z"),
+  tag: null,
+};
+
+describe("GET /api/bookmarks/trash", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("未認証の場合は 401", async () => {
+    mockGetUser.mockResolvedValue(null);
+
+    const res = await GET({} as never);
+
+    expect(res.status).toBe(401);
+    expect(mockGetDeleted).not.toHaveBeenCalled();
+  });
+
+  it("正常系: 削除済みブックマークを共通形式で返す", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockGetDeleted.mockResolvedValue([record] as never);
+
+    const res = await GET({} as never);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      bookmarks: [
+        {
+          id: "bm_1",
+          url: "https://a.com",
+          title: "A",
+          memo: null,
+          ogImage: null,
+          category: null,
+          createdAt: "2026-01-02T03:04:05.000Z",
+        },
+      ],
+    });
+    expect(mockGetDeleted).toHaveBeenCalledWith("user_1");
+  });
+});
+
+describe("DELETE /api/bookmarks/trash", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("未認証の場合は 401", async () => {
+    mockGetUser.mockResolvedValue(null);
+
+    const res = await DELETE({} as never);
+
+    expect(res.status).toBe(401);
+    expect(mockEmptyTrash).not.toHaveBeenCalled();
+  });
+
+  it("正常系: 204 でゴミ箱を空にする", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockEmptyTrash.mockResolvedValue({});
+
+    const res = await DELETE({} as never);
+
+    expect(res.status).toBe(204);
+    expect(mockEmptyTrash).toHaveBeenCalledWith("user_1");
+  });
+});

--- a/src/app/api/bookmarks/trash/route.ts
+++ b/src/app/api/bookmarks/trash/route.ts
@@ -1,0 +1,23 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { getUserByApiKey } from "@/lib/api-auth";
+import { serializeBookmark, unauthorized } from "@/lib/api-response";
+import { emptyTrash, getDeletedBookmarks } from "@/lib/bookmarks";
+
+export async function GET(req: NextRequest) {
+  const user = await getUserByApiKey(req);
+  if (!user) return unauthorized();
+
+  const bookmarks = await getDeletedBookmarks(user.id);
+
+  return NextResponse.json({ bookmarks: bookmarks.map(serializeBookmark) });
+}
+
+export async function DELETE(req: NextRequest) {
+  const user = await getUserByApiKey(req);
+  if (!user) return unauthorized();
+
+  await emptyTrash(user.id);
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/lib/bookmarks.test.ts
+++ b/src/lib/bookmarks.test.ts
@@ -401,17 +401,16 @@ describe("deleteBookmarks", () => {
 describe("restoreBookmark", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("正常系: deletedAt を null に戻して {} を返す", async () => {
+  it("正常系: deletedAt を null に戻して復元レコードを返す", async () => {
     mockBookmarkFindUnique.mockResolvedValue({ ...bookmark, deletedAt: new Date() } as never);
     mockBookmarkUpdate.mockResolvedValue(bookmark);
 
     const result = await restoreBookmark(userId, "bm_1");
 
-    expect(result).toEqual({});
-    expect(mockBookmarkUpdate).toHaveBeenCalledWith({
-      where: { id: "bm_1" },
-      data: { deletedAt: null },
-    });
+    expect(result).toEqual({ bookmark });
+    expect(mockBookmarkUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "bm_1" }, data: { deletedAt: null } }),
+    );
   });
 
   it("存在しないブックマークは error を返す", async () => {

--- a/src/lib/bookmarks.ts
+++ b/src/lib/bookmarks.ts
@@ -179,15 +179,22 @@ export async function deleteBookmarks(userId: string, ids: string[]): Promise<{ 
   return {};
 }
 
-export async function restoreBookmark(userId: string, id: string): Promise<{ error?: string }> {
+export async function restoreBookmark(
+  userId: string,
+  id: string,
+): Promise<{ bookmark?: BookmarkWithTag; error?: string }> {
   const bookmark = await prisma.bookmark.findUnique({ where: { id } });
   if (!bookmark) return { error: "ブックマークが見つかりません" };
   if (bookmark.userId !== userId) return { error: "権限がありません" };
 
   // deletedAt を null に戻す。tagId は保持されているため元のカテゴリに復帰する
-  await prisma.bookmark.update({ where: { id }, data: { deletedAt: null } });
+  const restored = await prisma.bookmark.update({
+    where: { id },
+    data: { deletedAt: null },
+    include: { tag: { select: { id: true, name: true } } },
+  });
 
-  return {};
+  return { bookmark: restored };
 }
 
 export async function emptyTrash(userId: string): Promise<{ error?: string }> {


### PR DESCRIPTION
## 概要

ブックマークの並び替え・ゴミ箱操作を **API キー認証の REST API** として公開する（T109 / エピック #253）。ロジックは `src/lib/bookmarks.ts` に集約済みのため、`src/app/api/` に薄い route ハンドラを追加し、UI 用の Server Actions と同じ lib 関数を共有する。

Closes #254

## 追加エンドポイント

| メソッド | パス | 動作 |
|---|---|---|
| `POST` | `/api/bookmarks/reorder` | 並び順を一括更新 → 200 |
| `GET` | `/api/bookmarks/trash` | ゴミ箱（削除済み）一覧 → 200 |
| `DELETE` | `/api/bookmarks/trash` | ゴミ箱を空に（完全削除）→ 204 |
| `POST` | `/api/bookmarks/:id/restore` | ゴミ箱から復元 → 200 + 復元リソース |

認証は既存 `getUserByApiKey`（`Authorization: Bearer`）を再利用。静的セグメント（`reorder`/`trash`）は動的 `[id]` より優先されるため既存ルートと共存。

## 主な変更

- `src/app/api/bookmarks/reorder/route.ts`（新）: `reorderBookmarks` を呼ぶ。`ids` が配列でない/空/非文字列を含む場合は 400、他ユーザー id 混入は 403
- `src/app/api/bookmarks/trash/route.ts`（新）: GET=`getDeletedBookmarks` / DELETE=`emptyTrash`
- `src/app/api/bookmarks/[id]/restore/route.ts`（新）: `restoreBookmark` を呼ぶ
- `src/lib/bookmarks.ts`: `restoreBookmark` を復元レコード（tag 込み）返却に拡張（T108 の create/update と一貫・**Server Actions は無変更**）
- 各ユニットテスト、`docs/api.md` 更新

## レビュアーへの補足

- **ベースブランチは `feature/rest-api`**（統合ブランチ）。全子 Issue 完了後に `feature/rest-api` → `develop` の PR を出す。
- **dev サーバの注意点**: `next dev`（Turbopack）は既存 `[id]` 配下に新規追加した `[id]/restore` を実行時に検出できず HTML 404 を返す挙動があった。`next build` のルート一覧には `ƒ /api/bookmarks/[id]/restore` が含まれ、`next start`（本番相当）では正常動作。**実運用に影響なし**。

## 確認

- ユニットテスト 193 件 green（T109 分 +14）／ biome / 型チェック / 本番ビルド成功
- 開発環境（本番ビルド → `next start`）で実機動作確認（全 10 項目 PASS）。エビデンスは #254 のコメント参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)