### PR TITLE
feat: OGP 取得 REST API を追加 (T111)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -351,7 +351,14 @@ curl -s -X DELETE -H "Authorization: Bearer ${LH_API_KEY}" \
 指定 URL の OGP メタデータ（タイトル・画像）を取得する。ブックマーク登録前のタイトル/画像の自動補完に使う。
 
 - `url` 未指定・`http`/`https` 以外の形式は **400**
-- **取得失敗・タイムアウト・SSRF ブロック（localhost / プライベート IP 等）でもエラーにせず、`{ title: null, image: null }` を 200 で返す**（ベストエフォート）
+- **取得失敗・タイムアウト・SSRF ブロックでもエラーにせず、`{ title: null, image: null }` を 200 で返す**（ベストエフォート）
+
+SSRF 対策として、以下のホストは fetch せず空を返す（`new URL()` で正規化した上で判定）：
+
+- ループバック（`127.0.0.0/8`・`::1`・`localhost`）、未指定（`0.0.0.0/8`・`::`）
+- プライベート IPv4（`10/8`・`172.16/12`・`192.168/16`）・CGNAT（`100.64/10`）・リンクローカル（`169.254/16`）
+- IPv6 ULA（`fc00::/7`）・リンクローカル（`fe80::/10`）
+- 上記に対応する IPv4-mapped IPv6（`::ffff:x`）表記
 
 ```bash
 curl -s -H "Authorization: Bearer ${LH_API_KEY}" \

--- a/docs/api.md
+++ b/docs/api.md
@@ -341,3 +341,30 @@ curl -s -X DELETE -H "Authorization: Bearer ${LH_API_KEY}" \
 ### レスポンス（204）
 
 ボディなし。未存在は `404`、他ユーザーのものは `403`。
+
+---
+
+# OGP 取得 API
+
+## `GET /api/ogp?url=<url>` — OGP メタデータ取得
+
+指定 URL の OGP メタデータ（タイトル・画像）を取得する。ブックマーク登録前のタイトル/画像の自動補完に使う。
+
+- `url` 未指定・`http`/`https` 以外の形式は **400**
+- **取得失敗・タイムアウト・SSRF ブロック（localhost / プライベート IP 等）でもエラーにせず、`{ title: null, image: null }` を 200 で返す**（ベストエフォート）
+
+```bash
+curl -s -H "Authorization: Bearer ${LH_API_KEY}" \
+  "http://localhost:3000/api/ogp?url=https://example.com" | jq
+```
+
+### レスポンス（200）
+
+```json
+{ "title": "Example Domain", "image": "https://example.com/og.png" }
+```
+
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `title` | string \| null | og:title（無ければ `<title>`）。取得できなければ null |
+| `image` | string \| null | og:image の絶対 URL。取得できなければ null |

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -21,6 +21,7 @@ Clerk によるメール/パスワード認証を使用する。
 | `/auth-error` | 公開（認証不要） |
 | `/api/bookmarks/**` | 公開（Clerk 認証は不要。API キー認証で保護。[`docs/api.md`](api.md) 参照） |
 | `/api/tags/**` | 公開（Clerk 認証は不要。API キー認証で保護。[`docs/api.md`](api.md) 参照） |
+| `/api/ogp/**` | 公開（Clerk 認証は不要。API キー認証で保護。[`docs/api.md`](api.md) 参照） |
 | 上記以外すべて | 認証必須（未認証は Clerk のサインイン画面へリダイレクト） |
 
 ### 開発環境のモックバイパス

--- a/src/app/(dashboard)/bookmarks/fetchOgp.test.ts
+++ b/src/app/(dashboard)/bookmarks/fetchOgp.test.ts
@@ -3,298 +3,39 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next/navigation", () => ({ redirect: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ getSession: vi.fn() }));
+vi.mock("@/lib/ogp", () => ({ fetchOgpData: vi.fn() }));
 
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth";
+import { fetchOgpData } from "@/lib/ogp";
 import { fetchOgp } from "./fetchOgp";
 
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
-
 const mockGetSession = vi.mocked(getSession);
+const mockFetchOgpData = vi.mocked(fetchOgpData);
 const mockRedirect = vi.mocked(redirect).mockImplementation(() => {
   throw new Error("NEXT_REDIRECT");
 });
 const session = { user: { id: "user_1", name: "Test", email: "test@example.com" } };
 
-const makeHtmlResponse = (html: string) =>
-  new Response(html, { status: 200, headers: { "Content-Type": "text/html" } });
-
-const makeBytesResponse = (bytes: Uint8Array, contentType: string) =>
-  new Response(bytes, { status: 200, headers: { "Content-Type": contentType } });
-
-// "日本語" を各エンコーディングで表したバイト列（ASCII 部分は latin1 でそのまま）
-const ascii = (str: string) => Array.from(str, (c) => c.charCodeAt(0));
-const buildBytes = (before: string, jaBytes: number[], after: string) =>
-  new Uint8Array([...ascii(before), ...jaBytes, ...ascii(after)]);
-
-const EUC_JP_NIHONGO = [0xc6, 0xfc, 0xcb, 0xdc, 0xb8, 0xec];
-const SHIFT_JIS_NIHONGO = [0x93, 0xfa, 0x96, 0x7b, 0x8c, 0xea];
-
 describe("fetchOgp", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockGetSession.mockResolvedValue(session);
-  });
+  beforeEach(() => vi.clearAllMocks());
 
-  it("未認証の場合は /sign-in にリダイレクトする", async () => {
+  it("未認証の場合は /sign-in にリダイレクトし lib を呼ばない", async () => {
     mockGetSession.mockResolvedValue(null);
 
     await expect(fetchOgp("https://example.com")).rejects.toThrow("NEXT_REDIRECT");
 
     expect(mockRedirect).toHaveBeenCalledWith("/sign-in");
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockFetchOgpData).not.toHaveBeenCalled();
   });
 
-  it("og:title と og:image を取得できる（property が content より前）", async () => {
-    mockFetch.mockResolvedValue(
-      makeHtmlResponse(`
-        <html>
-          <head>
-            <meta property="og:title" content="OG Title" />
-            <meta property="og:image" content="https://example.com/og.png" />
-          </head>
-        </html>
-      `),
-    );
+  it("認証済みの場合は fetchOgpData に委譲して結果を返す", async () => {
+    mockGetSession.mockResolvedValue(session);
+    mockFetchOgpData.mockResolvedValue({ title: "T", image: "https://example.com/og.png" });
 
     const result = await fetchOgp("https://example.com");
 
-    expect(result).toEqual({ title: "OG Title", image: "https://example.com/og.png" });
-  });
-
-  it("og:title と og:image を取得できる（content が property より前）", async () => {
-    mockFetch.mockResolvedValue(
-      makeHtmlResponse(`
-        <html>
-          <head>
-            <meta content="OG Title Reversed" property="og:title" />
-            <meta content="https://example.com/og-rev.png" property="og:image" />
-          </head>
-        </html>
-      `),
-    );
-
-    const result = await fetchOgp("https://example.com");
-
-    expect(result).toEqual({
-      title: "OG Title Reversed",
-      image: "https://example.com/og-rev.png",
-    });
-  });
-
-  it("タイトルの HTMLエンティティをデコードする", async () => {
-    mockFetch.mockResolvedValue(
-      makeHtmlResponse(
-        '<html><head><meta property="og:title" content="リリースノート &nbsp;|&nbsp; Gemini API" /></head></html>',
-      ),
-    );
-
-    const result = await fetchOgp("https://example.com");
-
-    expect(result.title).toBe("リリースノート  |  Gemini API");
-  });
-
-  it("<title> タグの HTMLエンティティもデコードする", async () => {
-    mockFetch.mockResolvedValue(
-      makeHtmlResponse(`
-        <html>
-          <head>
-            <title>A &amp; B &lt;test&gt;</title>
-          </head>
-        </html>
-      `),
-    );
-
-    const result = await fetchOgp("https://example.com");
-
-    expect(result.title).toBe("A & B <test>");
-  });
-
-  it("og:title がない場合 <title> タグからフォールバック取得する", async () => {
-    mockFetch.mockResolvedValue(
-      makeHtmlResponse(`
-        <html>
-          <head>
-            <title>  Page Title  </title>
-          </head>
-        </html>
-      `),
-    );
-
-    const result = await fetchOgp("https://example.com");
-
-    expect(result.title).toBe("Page Title");
-  });
-
-  it("相対パスの og:image を絶対 URL に解決する（ルート相対）", async () => {
-    mockFetch.mockResolvedValue(
-      makeHtmlResponse(`
-        <html>
-          <head>
-            <meta property="og:image" content="/images/og.png" />
-          </head>
-        </html>
-      `),
-    );
-
-    const result = await fetchOgp("https://example.com/page");
-
-    expect(result.image).toBe("https://example.com/images/og.png");
-  });
-
-  it("相対パスの og:image を絶対 URL に解決する（ページ相対）", async () => {
-    mockFetch.mockResolvedValue(
-      makeHtmlResponse(`
-        <html>
-          <head>
-            <meta property="og:image" content="img.png" />
-          </head>
-        </html>
-      `),
-    );
-
-    const result = await fetchOgp("https://example.com/blog/post");
-
-    expect(result.image).toBe("https://example.com/blog/img.png");
-  });
-
-  it("fetch が !res.ok の場合 error を返す", async () => {
-    mockFetch.mockResolvedValue(new Response("Not Found", { status: 404 }));
-
-    const result = await fetchOgp("https://example.com");
-
-    expect(result).toEqual({ error: "取得できませんでした" });
-  });
-
-  it("fetch が例外を投げた場合 error を返す", async () => {
-    mockFetch.mockRejectedValue(new Error("network error"));
-
-    const result = await fetchOgp("https://example.com");
-
-    expect(result).toEqual({ error: "取得できませんでした" });
-  });
-
-  it("AbortSignal タイムアウト（DOMException）でも error を返す", async () => {
-    const abortError = new DOMException("The operation was aborted", "AbortError");
-    mockFetch.mockRejectedValue(abortError);
-
-    const result = await fetchOgp("https://example.com");
-
-    expect(result).toEqual({ error: "取得できませんでした" });
-  });
-
-  it("http/https 以外のプロトコルは error を返す（SSRF対策）", async () => {
-    const result = await fetchOgp("file:///etc/passwd");
-    expect(result).toEqual({ error: "取得できませんでした" });
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it("localhost は error を返す（SSRF対策）", async () => {
-    const result = await fetchOgp("http://localhost/admin");
-    expect(result).toEqual({ error: "取得できませんでした" });
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it("og:image がない場合 image は undefined で返す", async () => {
-    mockFetch.mockResolvedValue(
-      makeHtmlResponse(`
-        <html>
-          <head>
-            <meta property="og:title" content="Title Only" />
-          </head>
-        </html>
-      `),
-    );
-
-    const result = await fetchOgp("https://example.com");
-
-    expect(result).toEqual({ title: "Title Only", image: undefined });
-  });
-
-  it("og:title も <title> タグもない場合 title は undefined で返す", async () => {
-    mockFetch.mockResolvedValue(makeHtmlResponse(`<html><head></head><body></body></html>`));
-
-    const result = await fetchOgp("https://example.com");
-
-    expect(result).toEqual({ title: undefined, image: undefined });
-  });
-
-  it("Content-Type ヘッダーの charset で EUC-JP のタイトルを decode する", async () => {
-    const bytes = buildBytes(
-      '<html><head><meta property="og:title" content="',
-      EUC_JP_NIHONGO,
-      '" /></head></html>',
-    );
-    mockFetch.mockResolvedValue(makeBytesResponse(bytes, "text/html; charset=EUC-JP"));
-
-    const result = await fetchOgp("https://example.com");
-
-    expect(result.title).toBe("日本語");
-  });
-
-  it("Content-Type ヘッダーの charset で Shift_JIS のタイトルを decode する", async () => {
-    const bytes = buildBytes(
-      '<html><head><meta property="og:title" content="',
-      SHIFT_JIS_NIHONGO,
-      '" /></head></html>',
-    );
-    mockFetch.mockResolvedValue(makeBytesResponse(bytes, "text/html; charset=Shift_JIS"));
-
-    const result = await fetchOgp("https://example.com");
-
-    expect(result.title).toBe("日本語");
-  });
-
-  it("<meta charset> で EUC-JP のタイトルを decode する（ヘッダーに charset なし）", async () => {
-    const bytes = buildBytes(
-      '<html><head><meta charset="euc-jp"><meta property="og:title" content="',
-      EUC_JP_NIHONGO,
-      '" /></head></html>',
-    );
-    mockFetch.mockResolvedValue(makeBytesResponse(bytes, "text/html"));
-
-    const result = await fetchOgp("https://example.com");
-
-    expect(result.title).toBe("日本語");
-  });
-
-  it("<meta http-equiv=Content-Type> で Shift_JIS のタイトルを decode する", async () => {
-    const bytes = buildBytes(
-      '<html><head><meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS"><meta property="og:title" content="',
-      SHIFT_JIS_NIHONGO,
-      '" /></head></html>',
-    );
-    mockFetch.mockResolvedValue(makeBytesResponse(bytes, "text/html"));
-
-    const result = await fetchOgp("https://example.com");
-
-    expect(result.title).toBe("日本語");
-  });
-
-  it("charset が判定できない場合は UTF-8 として decode する", async () => {
-    const bytes = new Uint8Array(
-      new TextEncoder().encode(
-        '<html><head><meta property="og:title" content="日本語タイトル" /></head></html>',
-      ),
-    );
-    mockFetch.mockResolvedValue(makeBytesResponse(bytes, "text/html"));
-
-    const result = await fetchOgp("https://example.com");
-
-    expect(result.title).toBe("日本語タイトル");
-  });
-
-  it("プライベートIPは error を返す（SSRF対策）", async () => {
-    for (const url of [
-      "http://10.0.0.1/secret",
-      "http://172.16.0.1/secret",
-      "http://192.168.1.1/secret",
-      "http://169.254.169.254/latest/meta-data",
-    ]) {
-      const result = await fetchOgp(url);
-      expect(result).toEqual({ error: "取得できませんでした" });
-      expect(mockFetch).not.toHaveBeenCalled();
-    }
+    expect(result).toEqual({ title: "T", image: "https://example.com/og.png" });
+    expect(mockFetchOgpData).toHaveBeenCalledWith("https://example.com");
   });
 });

--- a/src/app/(dashboard)/bookmarks/fetchOgp.ts
+++ b/src/app/(dashboard)/bookmarks/fetchOgp.ts
@@ -3,66 +3,7 @@
 import { redirect } from "next/navigation";
 
 import { getSession } from "@/lib/auth";
-
-function decodeHtmlEntities(str: string): string {
-  return str
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCharCode(Number.parseInt(code, 16)));
-}
-
-function normalizeCharset(charset: string): string {
-  const normalized = charset.trim().toLowerCase();
-  if (normalized === "utf8") return "utf-8";
-  if (normalized === "sjis" || normalized === "x-sjis") return "shift_jis";
-  return normalized;
-}
-
-function detectCharset(buffer: ArrayBuffer, contentType: string | null): string {
-  const headerCharset = contentType?.match(/charset=["']?([^"';\s]+)/i)?.[1];
-  if (headerCharset) return normalizeCharset(headerCharset);
-
-  // meta タグ判定用に先頭バイトを latin1 でスキャン（ASCII 範囲は文字コードに依らず一致する）
-  const head = new TextDecoder("latin1").decode(buffer.slice(0, 4096));
-  const metaCharset =
-    head.match(/<meta[^>]+charset=["']?([^"'/>\s]+)/i)?.[1] ??
-    head.match(/<meta[^>]+content=["'][^"']*charset=([^"';\s]+)/i)?.[1];
-  if (metaCharset) return normalizeCharset(metaCharset);
-
-  return "utf-8";
-}
-
-function decodeBuffer(buffer: ArrayBuffer, charset: string): string {
-  try {
-    return new TextDecoder(charset).decode(buffer);
-  } catch {
-    return new TextDecoder("utf-8").decode(buffer);
-  }
-}
-
-function isAllowedUrl(url: string): boolean {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return false;
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
-  const hostname = parsed.hostname;
-  if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") return false;
-  if (
-    /^10\./.test(hostname) ||
-    /^172\.(1[6-9]|2\d|3[01])\./.test(hostname) ||
-    /^192\.168\./.test(hostname) ||
-    /^169\.254\./.test(hostname)
-  )
-    return false;
-  return true;
-}
+import { fetchOgpData } from "@/lib/ogp";
 
 export async function fetchOgp(
   url: string,
@@ -70,38 +11,5 @@ export async function fetchOgp(
   const session = await getSession();
   if (!session) redirect("/sign-in");
 
-  if (!isAllowedUrl(url)) return { error: "取得できませんでした" };
-  try {
-    const res = await fetch(url, {
-      signal: AbortSignal.timeout(3000),
-      headers: { "User-Agent": "Mozilla/5.0 (compatible; link-hub-bot/1.0)" },
-    });
-    if (!res.ok) return { error: "取得できませんでした" };
-
-    const buffer = await res.arrayBuffer();
-    const charset = detectCharset(buffer, res.headers.get("content-type"));
-    const html = decodeBuffer(buffer, charset);
-
-    const getMetaContent = (property: string) =>
-      html.match(
-        new RegExp(`<meta[^>]+property=["']${property}["'][^>]+content=["']([^"']+)["']`, "i"),
-      )?.[1] ??
-      html.match(
-        new RegExp(`<meta[^>]+content=["']([^"']+)["'][^>]+property=["']${property}["']`, "i"),
-      )?.[1];
-
-    const rawTitle =
-      getMetaContent("og:title") ?? html.match(/<title[^>]*>([^<]+)<\/title>/i)?.[1]?.trim();
-    const title = rawTitle ? decodeHtmlEntities(rawTitle) : undefined;
-
-    const rawImage = getMetaContent("og:image");
-    let image: string | undefined;
-    if (rawImage) {
-      image = rawImage.startsWith("http") ? rawImage : new URL(rawImage, url).href;
-    }
-
-    return { title, image };
-  } catch {
-    return { error: "取得できませんでした" };
-  }
+  return fetchOgpData(url);
 }

--- a/src/app/api/ogp/route.test.ts
+++ b/src/app/api/ogp/route.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GET } from "./route";
+
+vi.mock("@/lib/api-auth", () => ({ getUserByApiKey: vi.fn() }));
+vi.mock("@/lib/ogp", () => ({ fetchOgpData: vi.fn() }));
+
+vi.stubEnv("DATABASE_URL", "postgresql://test");
+
+import { getUserByApiKey } from "@/lib/api-auth";
+import { fetchOgpData } from "@/lib/ogp";
+
+const mockGetUser = vi.mocked(getUserByApiKey);
+const mockFetchOgpData = vi.mocked(fetchOgpData);
+
+function req(query = "") {
+  return { nextUrl: { searchParams: new URLSearchParams(query) } } as never;
+}
+
+describe("GET /api/ogp", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("未認証の場合は 401", async () => {
+    mockGetUser.mockResolvedValue(null);
+
+    const res = await GET(req("url=https://example.com"));
+
+    expect(res.status).toBe(401);
+    expect(mockFetchOgpData).not.toHaveBeenCalled();
+  });
+
+  it("url 未指定は 400", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+
+    const res = await GET(req(""));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "url は必須です" });
+    expect(mockFetchOgpData).not.toHaveBeenCalled();
+  });
+
+  it("url の形式が不正なら 400", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+
+    const res = await GET(req("url=not-a-url"));
+
+    expect(res.status).toBe(400);
+    expect(mockFetchOgpData).not.toHaveBeenCalled();
+  });
+
+  it("http/https 以外は 400", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+
+    const res = await GET(req("url=ftp://example.com"));
+
+    expect(res.status).toBe(400);
+    expect(mockFetchOgpData).not.toHaveBeenCalled();
+  });
+
+  it("正常系: 200 で title/image を返す", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockFetchOgpData.mockResolvedValue({ title: "T", image: "https://example.com/og.png" });
+
+    const res = await GET(req("url=https://example.com"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ title: "T", image: "https://example.com/og.png" });
+    expect(mockFetchOgpData).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("取得失敗（error）の場合も 200 で空メタデータを返す", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockFetchOgpData.mockResolvedValue({ error: "取得できませんでした" });
+
+    const res = await GET(req("url=https://example.com"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ title: null, image: null });
+  });
+
+  it("title/image が undefined の場合は null に正規化する", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+    mockFetchOgpData.mockResolvedValue({ title: "T" });
+
+    const res = await GET(req("url=https://example.com"));
+
+    expect(await res.json()).toEqual({ title: "T", image: null });
+  });
+});

--- a/src/app/api/ogp/route.ts
+++ b/src/app/api/ogp/route.ts
@@ -1,0 +1,28 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { getUserByApiKey } from "@/lib/api-auth";
+import { jsonError, unauthorized } from "@/lib/api-response";
+import { fetchOgpData } from "@/lib/ogp";
+
+export async function GET(req: NextRequest) {
+  const user = await getUserByApiKey(req);
+  if (!user) return unauthorized();
+
+  const url = req.nextUrl.searchParams.get("url");
+  if (!url) return jsonError("url は必須です", 400);
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return jsonError("url の形式が不正です", 400);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return jsonError("url は http または https のみ対応しています", 400);
+  }
+
+  // 取得失敗・SSRF ブロックはエラーにせず空メタデータを返す（自動補完用途のためベストエフォート）
+  const result = await fetchOgpData(url);
+
+  return NextResponse.json({ title: result.title ?? null, image: result.image ?? null });
+}

--- a/src/lib/ogp.test.ts
+++ b/src/lib/ogp.test.ts
@@ -1,0 +1,281 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchOgpData } from "./ogp";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const makeHtmlResponse = (html: string) =>
+  new Response(html, { status: 200, headers: { "Content-Type": "text/html" } });
+
+const makeBytesResponse = (bytes: Uint8Array, contentType: string) =>
+  // Uint8Array は実行時に BodyInit として有効。TS 6 の TypedArray ジェネリック化で型が合わないため cast する
+  new Response(bytes as unknown as BodyInit, {
+    status: 200,
+    headers: { "Content-Type": contentType },
+  });
+
+// "日本語" を各エンコーディングで表したバイト列（ASCII 部分は latin1 でそのまま）
+const ascii = (str: string) => Array.from(str, (c) => c.charCodeAt(0));
+const buildBytes = (before: string, jaBytes: number[], after: string) =>
+  new Uint8Array([...ascii(before), ...jaBytes, ...ascii(after)]);
+
+const EUC_JP_NIHONGO = [0xc6, 0xfc, 0xcb, 0xdc, 0xb8, 0xec];
+const SHIFT_JIS_NIHONGO = [0x93, 0xfa, 0x96, 0x7b, 0x8c, 0xea];
+
+describe("fetchOgpData", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("og:title と og:image を取得できる（property が content より前）", async () => {
+    mockFetch.mockResolvedValue(
+      makeHtmlResponse(`
+        <html>
+          <head>
+            <meta property="og:title" content="OG Title" />
+            <meta property="og:image" content="https://example.com/og.png" />
+          </head>
+        </html>
+      `),
+    );
+
+    const result = await fetchOgpData("https://example.com");
+
+    expect(result).toEqual({ title: "OG Title", image: "https://example.com/og.png" });
+  });
+
+  it("og:title と og:image を取得できる（content が property より前）", async () => {
+    mockFetch.mockResolvedValue(
+      makeHtmlResponse(`
+        <html>
+          <head>
+            <meta content="OG Title Reversed" property="og:title" />
+            <meta content="https://example.com/og-rev.png" property="og:image" />
+          </head>
+        </html>
+      `),
+    );
+
+    const result = await fetchOgpData("https://example.com");
+
+    expect(result).toEqual({
+      title: "OG Title Reversed",
+      image: "https://example.com/og-rev.png",
+    });
+  });
+
+  it("タイトルの HTMLエンティティをデコードする", async () => {
+    mockFetch.mockResolvedValue(
+      makeHtmlResponse(
+        '<html><head><meta property="og:title" content="リリースノート &nbsp;|&nbsp; Gemini API" /></head></html>',
+      ),
+    );
+
+    const result = await fetchOgpData("https://example.com");
+
+    expect(result.title).toBe("リリースノート  |  Gemini API");
+  });
+
+  it("<title> タグの HTMLエンティティもデコードする", async () => {
+    mockFetch.mockResolvedValue(
+      makeHtmlResponse(`
+        <html>
+          <head>
+            <title>A &amp; B &lt;test&gt;</title>
+          </head>
+        </html>
+      `),
+    );
+
+    const result = await fetchOgpData("https://example.com");
+
+    expect(result.title).toBe("A & B <test>");
+  });
+
+  it("og:title がない場合 <title> タグからフォールバック取得する", async () => {
+    mockFetch.mockResolvedValue(
+      makeHtmlResponse(`
+        <html>
+          <head>
+            <title>  Page Title  </title>
+          </head>
+        </html>
+      `),
+    );
+
+    const result = await fetchOgpData("https://example.com");
+
+    expect(result.title).toBe("Page Title");
+  });
+
+  it("相対パスの og:image を絶対 URL に解決する（ルート相対）", async () => {
+    mockFetch.mockResolvedValue(
+      makeHtmlResponse(`
+        <html>
+          <head>
+            <meta property="og:image" content="/images/og.png" />
+          </head>
+        </html>
+      `),
+    );
+
+    const result = await fetchOgpData("https://example.com/page");
+
+    expect(result.image).toBe("https://example.com/images/og.png");
+  });
+
+  it("相対パスの og:image を絶対 URL に解決する（ページ相対）", async () => {
+    mockFetch.mockResolvedValue(
+      makeHtmlResponse(`
+        <html>
+          <head>
+            <meta property="og:image" content="img.png" />
+          </head>
+        </html>
+      `),
+    );
+
+    const result = await fetchOgpData("https://example.com/blog/post");
+
+    expect(result.image).toBe("https://example.com/blog/img.png");
+  });
+
+  it("fetch が !res.ok の場合 error を返す", async () => {
+    mockFetch.mockResolvedValue(new Response("Not Found", { status: 404 }));
+
+    const result = await fetchOgpData("https://example.com");
+
+    expect(result).toEqual({ error: "取得できませんでした" });
+  });
+
+  it("fetch が例外を投げた場合 error を返す", async () => {
+    mockFetch.mockRejectedValue(new Error("network error"));
+
+    const result = await fetchOgpData("https://example.com");
+
+    expect(result).toEqual({ error: "取得できませんでした" });
+  });
+
+  it("AbortSignal タイムアウト（DOMException）でも error を返す", async () => {
+    const abortError = new DOMException("The operation was aborted", "AbortError");
+    mockFetch.mockRejectedValue(abortError);
+
+    const result = await fetchOgpData("https://example.com");
+
+    expect(result).toEqual({ error: "取得できませんでした" });
+  });
+
+  it("http/https 以外のプロトコルは error を返す（SSRF対策）", async () => {
+    const result = await fetchOgpData("file:///etc/passwd");
+    expect(result).toEqual({ error: "取得できませんでした" });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("localhost は error を返す（SSRF対策）", async () => {
+    const result = await fetchOgpData("http://localhost/admin");
+    expect(result).toEqual({ error: "取得できませんでした" });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("og:image がない場合 image は undefined で返す", async () => {
+    mockFetch.mockResolvedValue(
+      makeHtmlResponse(`
+        <html>
+          <head>
+            <meta property="og:title" content="Title Only" />
+          </head>
+        </html>
+      `),
+    );
+
+    const result = await fetchOgpData("https://example.com");
+
+    expect(result).toEqual({ title: "Title Only", image: undefined });
+  });
+
+  it("og:title も <title> タグもない場合 title は undefined で返す", async () => {
+    mockFetch.mockResolvedValue(makeHtmlResponse(`<html><head></head><body></body></html>`));
+
+    const result = await fetchOgpData("https://example.com");
+
+    expect(result).toEqual({ title: undefined, image: undefined });
+  });
+
+  it("Content-Type ヘッダーの charset で EUC-JP のタイトルを decode する", async () => {
+    const bytes = buildBytes(
+      '<html><head><meta property="og:title" content="',
+      EUC_JP_NIHONGO,
+      '" /></head></html>',
+    );
+    mockFetch.mockResolvedValue(makeBytesResponse(bytes, "text/html; charset=EUC-JP"));
+
+    const result = await fetchOgpData("https://example.com");
+
+    expect(result.title).toBe("日本語");
+  });
+
+  it("Content-Type ヘッダーの charset で Shift_JIS のタイトルを decode する", async () => {
+    const bytes = buildBytes(
+      '<html><head><meta property="og:title" content="',
+      SHIFT_JIS_NIHONGO,
+      '" /></head></html>',
+    );
+    mockFetch.mockResolvedValue(makeBytesResponse(bytes, "text/html; charset=Shift_JIS"));
+
+    const result = await fetchOgpData("https://example.com");
+
+    expect(result.title).toBe("日本語");
+  });
+
+  it("<meta charset> で EUC-JP のタイトルを decode する（ヘッダーに charset なし）", async () => {
+    const bytes = buildBytes(
+      '<html><head><meta charset="euc-jp"><meta property="og:title" content="',
+      EUC_JP_NIHONGO,
+      '" /></head></html>',
+    );
+    mockFetch.mockResolvedValue(makeBytesResponse(bytes, "text/html"));
+
+    const result = await fetchOgpData("https://example.com");
+
+    expect(result.title).toBe("日本語");
+  });
+
+  it("<meta http-equiv=Content-Type> で Shift_JIS のタイトルを decode する", async () => {
+    const bytes = buildBytes(
+      '<html><head><meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS"><meta property="og:title" content="',
+      SHIFT_JIS_NIHONGO,
+      '" /></head></html>',
+    );
+    mockFetch.mockResolvedValue(makeBytesResponse(bytes, "text/html"));
+
+    const result = await fetchOgpData("https://example.com");
+
+    expect(result.title).toBe("日本語");
+  });
+
+  it("charset が判定できない場合は UTF-8 として decode する", async () => {
+    const bytes = new Uint8Array(
+      new TextEncoder().encode(
+        '<html><head><meta property="og:title" content="日本語タイトル" /></head></html>',
+      ),
+    );
+    mockFetch.mockResolvedValue(makeBytesResponse(bytes, "text/html"));
+
+    const result = await fetchOgpData("https://example.com");
+
+    expect(result.title).toBe("日本語タイトル");
+  });
+
+  it("プライベートIPは error を返す（SSRF対策）", async () => {
+    for (const url of [
+      "http://10.0.0.1/secret",
+      "http://172.16.0.1/secret",
+      "http://192.168.1.1/secret",
+      "http://169.254.169.254/latest/meta-data",
+    ]) {
+      const result = await fetchOgpData(url);
+      expect(result).toEqual({ error: "取得できませんでした" });
+      expect(mockFetch).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/src/lib/ogp.test.ts
+++ b/src/lib/ogp.test.ts
@@ -278,4 +278,38 @@ describe("fetchOgpData", () => {
       expect(mockFetch).not.toHaveBeenCalled();
     }
   });
+
+  it("IPv6 系・0.0.0.0 など SSRF バイパスを遮断する", async () => {
+    for (const url of [
+      "http://0/", // 0.0.0.0 に正規化
+      "http://0.0.0.0/",
+      "http://[::1]/", // IPv6 ループバック
+      "http://[::ffff:127.0.0.1]/", // IPv4-mapped ループバック
+      "http://[::ffff:169.254.169.254]/", // IPv4-mapped メタデータIP
+      "http://[fc00::1]/", // ULA
+      "http://[fd12:3456::1]/", // ULA
+      "http://[fe80::1]/", // リンクローカル
+    ]) {
+      const result = await fetchOgpData(url);
+      expect(result, `${url} should be blocked`).toEqual({ error: "取得できませんでした" });
+      expect(mockFetch, `${url} should not fetch`).not.toHaveBeenCalled();
+    }
+  });
+
+  it("10進数/16進数表記の IPv4 も new URL 正規化で遮断される", async () => {
+    for (const url of ["http://2130706433/", "http://0x7f000001/"]) {
+      const result = await fetchOgpData(url);
+      expect(result, `${url} should be blocked`).toEqual({ error: "取得できませんでした" });
+      expect(mockFetch).not.toHaveBeenCalled();
+    }
+  });
+
+  it("グローバル IPv6 は許可して fetch する", async () => {
+    mockFetch.mockResolvedValue(makeHtmlResponse("<html><head><title>OK</title></head></html>"));
+
+    const result = await fetchOgpData("http://[2606:2800:220:1:248:1893:25c8:1946]/");
+
+    expect(result.title).toBe("OK");
+    expect(mockFetch).toHaveBeenCalled();
+  });
 });

--- a/src/lib/ogp.ts
+++ b/src/lib/ogp.ts
@@ -1,3 +1,5 @@
+import net from "node:net";
+
 function decodeHtmlEntities(str: string): string {
   return str
     .replace(/&nbsp;/g, " ")
@@ -38,7 +40,59 @@ function decodeBuffer(buffer: ArrayBuffer, charset: string): string {
   }
 }
 
-/** SSRF 対策: http/https のみ許可し、localhost・プライベート IP 帯を遮断する。 */
+/** プライベート・ループバック・リンクローカル等の遮断対象 IPv4 か判定する。 */
+function isBlockedIpv4(ip: string): boolean {
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
+    return true; // 異常な形式は安全側に倒して遮断
+  }
+  const [a, b] = parts;
+  return (
+    a === 0 || // 0.0.0.0/8（0.0.0.0 含む）
+    a === 10 || // 10.0.0.0/8 プライベート
+    a === 127 || // ループバック
+    (a === 100 && b >= 64 && b <= 127) || // 100.64/10 CGNAT
+    (a === 169 && b === 254) || // 169.254/16 リンクローカル（クラウドメタデータ）
+    (a === 172 && b >= 16 && b <= 31) || // 172.16/12 プライベート
+    (a === 192 && b === 168) // 192.168/16 プライベート
+  );
+}
+
+/** 遮断対象ホスト（プライベート/ループバック/リンクローカル/ULA/IPv4-mapped 等）か判定する。 */
+function isBlockedHostname(hostname: string): boolean {
+  // new URL() は IPv6 を [...] で囲むため外す
+  const host =
+    hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+
+  if (net.isIPv4(host)) return isBlockedIpv4(host);
+
+  if (net.isIPv6(host)) {
+    const v6 = host.toLowerCase();
+    if (v6 === "::" || v6 === "::1") return true; // 未指定 / ループバック
+    // IPv4-mapped（::ffff:x）: 埋め込まれた IPv4 を取り出して判定する
+    const mapped = v6.match(/^::ffff:(.+)$/);
+    if (mapped) {
+      const rest = mapped[1];
+      if (net.isIPv4(rest)) return isBlockedIpv4(rest);
+      const hex = rest.match(/^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+      if (hex) {
+        const hi = Number.parseInt(hex[1], 16);
+        const lo = Number.parseInt(hex[2], 16);
+        return isBlockedIpv4(`${(hi >> 8) & 255}.${hi & 255}.${(lo >> 8) & 255}.${lo & 255}`);
+      }
+      return true; // 未知の mapped 形式は遮断
+    }
+    if (/^fe[89ab]/.test(v6)) return true; // fe80::/10 リンクローカル
+    if (/^f[cd]/.test(v6)) return true; // fc00::/7 ULA
+    return false;
+  }
+
+  // IP リテラルでない（ドメイン名）: localhost 系のみ遮断
+  const lower = hostname.toLowerCase();
+  return lower === "localhost" || lower.endsWith(".localhost");
+}
+
+/** SSRF 対策: http/https のみ許可し、内部ネットワーク宛のホストを遮断する。 */
 function isAllowedUrl(url: string): boolean {
   let parsed: URL;
   try {
@@ -47,16 +101,7 @@ function isAllowedUrl(url: string): boolean {
     return false;
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
-  const hostname = parsed.hostname;
-  if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") return false;
-  if (
-    /^10\./.test(hostname) ||
-    /^172\.(1[6-9]|2\d|3[01])\./.test(hostname) ||
-    /^192\.168\./.test(hostname) ||
-    /^169\.254\./.test(hostname)
-  )
-    return false;
-  return true;
+  return !isBlockedHostname(parsed.hostname);
 }
 
 /**

--- a/src/lib/ogp.ts
+++ b/src/lib/ogp.ts
@@ -1,0 +1,103 @@
+function decodeHtmlEntities(str: string): string {
+  return str
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCharCode(Number.parseInt(code, 16)));
+}
+
+function normalizeCharset(charset: string): string {
+  const normalized = charset.trim().toLowerCase();
+  if (normalized === "utf8") return "utf-8";
+  if (normalized === "sjis" || normalized === "x-sjis") return "shift_jis";
+  return normalized;
+}
+
+function detectCharset(buffer: ArrayBuffer, contentType: string | null): string {
+  const headerCharset = contentType?.match(/charset=["']?([^"';\s]+)/i)?.[1];
+  if (headerCharset) return normalizeCharset(headerCharset);
+
+  // meta タグ判定用に先頭バイトを latin1 でスキャン（ASCII 範囲は文字コードに依らず一致する）
+  const head = new TextDecoder("latin1").decode(buffer.slice(0, 4096));
+  const metaCharset =
+    head.match(/<meta[^>]+charset=["']?([^"'/>\s]+)/i)?.[1] ??
+    head.match(/<meta[^>]+content=["'][^"']*charset=([^"';\s]+)/i)?.[1];
+  if (metaCharset) return normalizeCharset(metaCharset);
+
+  return "utf-8";
+}
+
+function decodeBuffer(buffer: ArrayBuffer, charset: string): string {
+  try {
+    return new TextDecoder(charset).decode(buffer);
+  } catch {
+    return new TextDecoder("utf-8").decode(buffer);
+  }
+}
+
+/** SSRF 対策: http/https のみ許可し、localhost・プライベート IP 帯を遮断する。 */
+function isAllowedUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+  const hostname = parsed.hostname;
+  if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") return false;
+  if (
+    /^10\./.test(hostname) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(hostname) ||
+    /^192\.168\./.test(hostname) ||
+    /^169\.254\./.test(hostname)
+  )
+    return false;
+  return true;
+}
+
+/**
+ * 指定 URL の OGP メタデータ（title / image）を取得する。認証は含まない（呼び出し側で行う）。
+ * SSRF 遮断・取得失敗・タイムアウト時は `{ error }` を返す。
+ */
+export async function fetchOgpData(
+  url: string,
+): Promise<{ title?: string; image?: string; error?: string }> {
+  if (!isAllowedUrl(url)) return { error: "取得できませんでした" };
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(3000),
+      headers: { "User-Agent": "Mozilla/5.0 (compatible; link-hub-bot/1.0)" },
+    });
+    if (!res.ok) return { error: "取得できませんでした" };
+
+    const buffer = await res.arrayBuffer();
+    const charset = detectCharset(buffer, res.headers.get("content-type"));
+    const html = decodeBuffer(buffer, charset);
+
+    const getMetaContent = (property: string) =>
+      html.match(
+        new RegExp(`<meta[^>]+property=["']${property}["'][^>]+content=["']([^"']+)["']`, "i"),
+      )?.[1] ??
+      html.match(
+        new RegExp(`<meta[^>]+content=["']([^"']+)["'][^>]+property=["']${property}["']`, "i"),
+      )?.[1];
+
+    const rawTitle =
+      getMetaContent("og:title") ?? html.match(/<title[^>]*>([^<]+)<\/title>/i)?.[1]?.trim();
+    const title = rawTitle ? decodeHtmlEntities(rawTitle) : undefined;
+
+    const rawImage = getMetaContent("og:image");
+    let image: string | undefined;
+    if (rawImage) {
+      image = rawImage.startsWith("http") ? rawImage : new URL(rawImage, url).href;
+    }
+
+    return { title, image };
+  } catch {
+    return { error: "取得できませんでした" };
+  }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,6 +8,7 @@ const isPublicRoute = createRouteMatcher([
   // 外部連携用 REST API は Clerk ではなく API キー認証で保護する
   "/api/bookmarks(.*)",
   "/api/tags(.*)",
+  "/api/ogp(.*)",
 ]);
 
 export default clerkMiddleware(async (auth, request) => {


### PR DESCRIPTION
## 概要

指定 URL の OGP メタデータ（タイトル・画像）を取得する REST API を **API キー認証**で公開する（T111 / エピック #253）。ブックマーク登録前のタイトル/画像の自動補完に使う。

既存の OGP 取得ロジック（Server Action `fetchOgp`）から**認証を除いた純粋ロジックを `src/lib/ogp.ts` に切り出し**、UI（Server Action）と外部 API で共有する。

Closes #256

## 追加エンドポイント

| メソッド | パス | 動作 |
|---|---|---|
| `GET` | `/api/ogp?url=<url>` | OGP メタデータ取得 → 200 `{ title, image }` |

- `url` 未指定・`http`/`https` 以外 → **400**
- 取得失敗・タイムアウト・**SSRF ブロック（localhost / プライベート IP）→ 200 で `{ title: null, image: null }`**（ベストエフォート）

## 主な変更

- `src/lib/ogp.ts`（新）: `fetchOgpData(url)`。SSRF 対策（localhost・10./172.16-31./192.168./169.254. 遮断）・charset 判定・OGP パースを内包（**認証なし**）
- `src/app/(dashboard)/bookmarks/fetchOgp.ts`: `getSession`→redirect の後 `fetchOgpData` に委譲する薄い Server Action に
- `src/app/api/ogp/route.ts`（新）: API キー認証＋URL 検証＋`fetchOgpData` 呼び出し
- `src/proxy.ts`: public ルートに `"/api/ogp(.*)"` を追加
- テスト: OGP ロジックを `src/lib/ogp.test.ts` に移設（`fetchOgpData` を直接テスト）、`fetchOgp.test.ts` は認証ラッパのテストに簡素化、`route.test.ts` 新設
- `docs/api.md`・`docs/auth.md` 更新

## レビュアーへの補足

- **ベースブランチは `feature/rest-api`**（統合ブランチ）。本 PR で Phase 8 の子 Issue（T108〜T111）が全完了となり、次に `feature/rest-api` → `develop` の統合 PR を出す。
- **SSRF 対策は `lib/ogp.ts` に維持**。外部 URL を代理取得するため必須。実機で AWS メタデータ IP `169.254.169.254` の遮断も確認済み。
- 型チェックはフィルタなしで **src エラー 0**（テスト移設に伴い、従来 `fetchOgp.test.ts` にあった既存の `Uint8Array`→`BodyInit` 型エラーも解消）。

## 確認

- ユニットテスト 228 件 green（T111 分 +8）／ biome / 型チェック（src エラー 0）/ 本番ビルド成功
- 開発環境（本番ビルド → `next start`）で実機動作確認（全 8 項目 PASS・SSRF 遮断含む）。エビデンスは #256 のコメント参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)