### PR TITLE
feat: tags・ogp のバリデーションを Zod スキーマに統合 (T115)

### DIFF
--- a/src/app/api/bookmarks/reorder/route.ts
+++ b/src/app/api/bookmarks/reorder/route.ts
@@ -4,7 +4,7 @@ import { getUserByApiKey } from "@/lib/api-auth";
 import { jsonError, statusForError, unauthorized } from "@/lib/api-response";
 import { reorderBookmarks } from "@/lib/bookmarks";
 import { firstZodError } from "@/lib/schemas/_zod-error";
-import { reorderBodySchema } from "@/lib/schemas/bookmark";
+import { reorderBodySchema } from "@/lib/schemas/common";
 
 export async function POST(req: NextRequest) {
   const user = await getUserByApiKey(req);

--- a/src/app/api/ogp/route.ts
+++ b/src/app/api/ogp/route.ts
@@ -3,26 +3,18 @@ import { type NextRequest, NextResponse } from "next/server";
 import { getUserByApiKey } from "@/lib/api-auth";
 import { jsonError, unauthorized } from "@/lib/api-response";
 import { fetchOgpData } from "@/lib/ogp";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { ogpQuerySchema } from "@/lib/schemas/ogp";
 
 export async function GET(req: NextRequest) {
   const user = await getUserByApiKey(req);
   if (!user) return unauthorized();
 
-  const url = req.nextUrl.searchParams.get("url");
-  if (!url) return jsonError("url は必須です", 400);
-
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return jsonError("url の形式が不正です", 400);
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    return jsonError("url は http または https のみ対応しています", 400);
-  }
+  const parsed = ogpQuerySchema.safeParse({ url: req.nextUrl.searchParams.get("url") });
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
 
   // 取得失敗・SSRF ブロックはエラーにせず空メタデータを返す（自動補完用途のためベストエフォート）
-  const result = await fetchOgpData(url);
+  const result = await fetchOgpData(parsed.data.url);
 
   return NextResponse.json({ title: result.title ?? null, image: result.image ?? null });
 }

--- a/src/app/api/tags/[id]/route.ts
+++ b/src/app/api/tags/[id]/route.ts
@@ -2,6 +2,8 @@ import { type NextRequest, NextResponse } from "next/server";
 
 import { getUserByApiKey } from "@/lib/api-auth";
 import { jsonError, statusForError, unauthorized } from "@/lib/api-response";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { tagBodySchema } from "@/lib/schemas/tag";
 import { deleteTag, updateTag } from "@/lib/tags";
 
 type RouteContext = { params: Promise<{ id: string }> };
@@ -13,11 +15,10 @@ export async function PATCH(req: NextRequest, { params }: RouteContext) {
   const { id } = await params;
 
   const body = await req.json().catch(() => null);
-  if (!body || typeof body !== "object" || typeof body.name !== "string") {
-    return jsonError("name は必須です", 400);
-  }
+  const parsed = tagBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
 
-  const result = await updateTag(user.id, id, body.name);
+  const result = await updateTag(user.id, id, parsed.data.name);
   if (result.conflict) return jsonError("同名のカテゴリが既に存在します", 409);
   if (result.error) return jsonError(result.error, statusForError(result.error));
   if (!result.tag) return jsonError("更新に失敗しました", 500);

--- a/src/app/api/tags/reorder/route.ts
+++ b/src/app/api/tags/reorder/route.ts
@@ -2,6 +2,8 @@ import { type NextRequest, NextResponse } from "next/server";
 
 import { getUserByApiKey } from "@/lib/api-auth";
 import { jsonError, statusForError, unauthorized } from "@/lib/api-response";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { reorderBodySchema } from "@/lib/schemas/common";
 import { reorderTags } from "@/lib/tags";
 
 export async function POST(req: NextRequest) {
@@ -9,13 +11,10 @@ export async function POST(req: NextRequest) {
   if (!user) return unauthorized();
 
   const body = await req.json().catch(() => null);
-  const ids = body?.ids;
-  if (!Array.isArray(ids) || ids.some((id) => typeof id !== "string")) {
-    return jsonError("ids は文字列の配列で指定してください", 400);
-  }
-  if (ids.length === 0) return jsonError("ids は必須です", 400);
+  const parsed = reorderBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
 
-  const result = await reorderTags(user.id, ids);
+  const result = await reorderTags(user.id, parsed.data.ids);
   if (result.error) return jsonError(result.error, statusForError(result.error));
 
   return new NextResponse(null, { status: 200 });

--- a/src/app/api/tags/route.test.ts
+++ b/src/app/api/tags/route.test.ts
@@ -89,6 +89,17 @@ describe("POST /api/tags", () => {
     expect(mockCreateTag).not.toHaveBeenCalled();
   });
 
+  it("body が非オブジェクト（配列・null）の場合は 400（日本語メッセージ）", async () => {
+    mockGetUser.mockResolvedValue({ id: "user_1" });
+
+    for (const bad of [[1, 2, 3], null]) {
+      const res = await POST(jsonReq(bad));
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "リクエストボディが不正です" });
+    }
+    expect(mockCreateTag).not.toHaveBeenCalled();
+  });
+
   it("同名カテゴリは 409", async () => {
     mockGetUser.mockResolvedValue({ id: "user_1" });
     mockCreateTag.mockResolvedValue({ conflict: true, tag: { id: "t1", name: "React" } });

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -2,6 +2,8 @@ import { type NextRequest, NextResponse } from "next/server";
 
 import { getUserByApiKey } from "@/lib/api-auth";
 import { jsonError, statusForError, unauthorized } from "@/lib/api-response";
+import { firstZodError } from "@/lib/schemas/_zod-error";
+import { tagBodySchema } from "@/lib/schemas/tag";
 import { createTag, getTags, getTagsWithCount } from "@/lib/tags";
 
 export async function GET(req: NextRequest) {
@@ -19,11 +21,10 @@ export async function POST(req: NextRequest) {
   if (!user) return unauthorized();
 
   const body = await req.json().catch(() => null);
-  if (!body || typeof body !== "object" || typeof body.name !== "string") {
-    return jsonError("name は必須です", 400);
-  }
+  const parsed = tagBodySchema.safeParse(body);
+  if (!parsed.success) return jsonError(firstZodError(parsed.error), 400);
 
-  const result = await createTag(user.id, body.name);
+  const result = await createTag(user.id, parsed.data.name);
   if (result.conflict) return jsonError("同名のカテゴリが既に存在します", 409);
   if (result.error) return jsonError(result.error, statusForError(result.error));
   if (!result.tag) return jsonError("作成に失敗しました", 500);

--- a/src/lib/schemas/bookmark.test.ts
+++ b/src/lib/schemas/bookmark.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from "vitest";
 
 import { firstZodError } from "./_zod-error";
-import { bookmarkBodySchema, reorderBodySchema } from "./bookmark";
+import { bookmarkBodySchema } from "./bookmark";
 
 /** safeParse して先頭エラーメッセージ（成功時 null）を返すヘルパー。 */
 function parseError(schema: typeof bookmarkBodySchema, input: unknown): string | null {
@@ -111,34 +111,6 @@ describe("bookmarkBodySchema", () => {
   it("body が非オブジェクト（配列・文字列・数値・null）はボディ不正の日本語エラー", () => {
     for (const v of [[1, 2, 3], "x", 42, null]) {
       expect(parseError(bookmarkBodySchema, v)).toBe("リクエストボディが不正です");
-    }
-  });
-});
-
-describe("reorderBodySchema", () => {
-  it("正常系: 文字列配列で通過", () => {
-    expect(reorderBodySchema.safeParse({ ids: ["a", "b"] }).success).toBe(true);
-  });
-
-  it("配列でない・非文字列要素は配列エラー", () => {
-    const msg = "ids は文字列の配列で指定してください";
-    const e1 = reorderBodySchema.safeParse({ ids: "a,b" });
-    expect(!e1.success && firstZodError(e1.error)).toBe(msg);
-    const e2 = reorderBodySchema.safeParse({ ids: ["a", 1] });
-    expect(!e2.success && firstZodError(e2.error)).toBe(msg);
-  });
-
-  it("空配列・ids 欠落は必須エラー", () => {
-    const e1 = reorderBodySchema.safeParse({ ids: [] });
-    expect(!e1.success && firstZodError(e1.error)).toBe("ids は必須です");
-    const e2 = reorderBodySchema.safeParse({});
-    expect(!e2.success && firstZodError(e2.error)).toBe("ids は文字列の配列で指定してください");
-  });
-
-  it("body が非オブジェクト（配列・文字列・数値・null）はボディ不正の日本語エラー", () => {
-    for (const v of [[], "x", 42, null]) {
-      const r = reorderBodySchema.safeParse(v);
-      expect(!r.success && firstZodError(r.error)).toBe("リクエストボディが不正です");
     }
   });
 });

--- a/src/lib/schemas/bookmark.ts
+++ b/src/lib/schemas/bookmark.ts
@@ -1,23 +1,8 @@
 import { z } from "zod";
 
-const SORT_ORDER_MSG = "sortOrder は 0 以上 2147483647 以下の整数で指定してください";
+import { httpUrlField } from "./common";
 
-const urlField = z.string({ error: "url は必須です" }).superRefine((val, ctx) => {
-  if (val.trim() === "") {
-    ctx.addIssue({ code: "custom", message: "url は必須です" });
-    return;
-  }
-  let parsed: URL;
-  try {
-    parsed = new URL(val);
-  } catch {
-    ctx.addIssue({ code: "custom", message: "url の形式が不正です" });
-    return;
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    ctx.addIssue({ code: "custom", message: "url は http または https のみ対応しています" });
-  }
-});
+const SORT_ORDER_MSG = "sortOrder は 0 以上 2147483647 以下の整数で指定してください";
 
 const titleField = z
   .string({ error: "title は必須です" })
@@ -33,7 +18,7 @@ const titleField = z
  */
 export const bookmarkBodySchema = z.object(
   {
-    url: urlField,
+    url: httpUrlField,
     title: titleField,
     memo: z.string({ error: "memo は文字列で指定してください" }).optional(),
     ogImage: z.string({ error: "ogImage は文字列で指定してください" }).optional(),
@@ -51,14 +36,4 @@ export const bookmarkBodySchema = z.object(
 
 export type BookmarkBody = z.infer<typeof bookmarkBodySchema>;
 
-/** 並び替え（reorder）の body スキーマ。 */
-export const reorderBodySchema = z.object(
-  {
-    ids: z
-      .array(z.string({ error: "ids は文字列の配列で指定してください" }), {
-        error: "ids は文字列の配列で指定してください",
-      })
-      .min(1, { error: "ids は必須です" }),
-  },
-  { error: "リクエストボディが不正です" },
-);
+// 並び替え（reorder）の body スキーマは共通のため src/lib/schemas/common.ts に移設。

--- a/src/lib/schemas/common.test.ts
+++ b/src/lib/schemas/common.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { firstZodError } from "./_zod-error";
+import { httpUrlField, reorderBodySchema } from "./common";
+
+function urlError(input: unknown): string | null {
+  const r = httpUrlField.safeParse(input);
+  return r.success ? null : firstZodError(r.error);
+}
+
+function reorderError(input: unknown): string | null {
+  const r = reorderBodySchema.safeParse(input);
+  return r.success ? null : firstZodError(r.error);
+}
+
+describe("httpUrlField", () => {
+  it("http/https の URL は通過", () => {
+    expect(urlError("https://example.com")).toBeNull();
+    expect(urlError("http://example.com/path")).toBeNull();
+  });
+
+  it("無い・空・非文字列は必須エラー", () => {
+    expect(urlError(undefined)).toBe("url は必須です");
+    expect(urlError(null)).toBe("url は必須です");
+    expect(urlError("  ")).toBe("url は必須です");
+    expect(urlError(123)).toBe("url は必須です");
+  });
+
+  it("形式不正・非 http/https はそれぞれのエラー", () => {
+    expect(urlError("not a url")).toBe("url の形式が不正です");
+    expect(urlError("ftp://example.com")).toBe("url は http または https のみ対応しています");
+  });
+});
+
+describe("reorderBodySchema", () => {
+  it("正常系: 文字列配列で通過", () => {
+    expect(reorderBodySchema.safeParse({ ids: ["a", "b"] }).success).toBe(true);
+  });
+
+  it("配列でない・非文字列要素は配列エラー", () => {
+    expect(reorderError({ ids: "a,b" })).toBe("ids は文字列の配列で指定してください");
+    expect(reorderError({ ids: ["a", 1] })).toBe("ids は文字列の配列で指定してください");
+  });
+
+  it("空配列・ids 欠落は必須／配列エラー", () => {
+    expect(reorderError({ ids: [] })).toBe("ids は必須です");
+    expect(reorderError({})).toBe("ids は文字列の配列で指定してください");
+  });
+
+  it("body が非オブジェクト（配列・文字列・数値・null）はボディ不正の日本語エラー", () => {
+    for (const v of [[], "x", 42, null]) {
+      expect(reorderError(v)).toBe("リクエストボディが不正です");
+    }
+  });
+});

--- a/src/lib/schemas/common.ts
+++ b/src/lib/schemas/common.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+/**
+ * http/https の URL を検証する共有フィールド（必須/形式/スキームの 3 メッセージ）。
+ * ブックマークの `url` と OGP 取得の `url` クエリで共有する。
+ */
+export const httpUrlField = z.string({ error: "url は必須です" }).superRefine((val, ctx) => {
+  if (val.trim() === "") {
+    ctx.addIssue({ code: "custom", message: "url は必須です" });
+    return;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(val);
+  } catch {
+    ctx.addIssue({ code: "custom", message: "url の形式が不正です" });
+    return;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    ctx.addIssue({ code: "custom", message: "url は http または https のみ対応しています" });
+  }
+});
+
+/**
+ * 並び替え（reorder）の body スキーマ（ブックマーク・カテゴリ共通）。
+ * 第2引数の `error` は body 自体が非オブジェクトのときのメッセージ。
+ */
+export const reorderBodySchema = z.object(
+  {
+    ids: z
+      .array(z.string({ error: "ids は文字列の配列で指定してください" }), {
+        error: "ids は文字列の配列で指定してください",
+      })
+      .min(1, { error: "ids は必須です" }),
+  },
+  { error: "リクエストボディが不正です" },
+);

--- a/src/lib/schemas/ogp.test.ts
+++ b/src/lib/schemas/ogp.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { firstZodError } from "./_zod-error";
+import { ogpQuerySchema } from "./ogp";
+
+function parseError(input: unknown): string | null {
+  const r = ogpQuerySchema.safeParse(input);
+  return r.success ? null : firstZodError(r.error);
+}
+
+describe("ogpQuerySchema", () => {
+  it("正常系: http/https の url は通過", () => {
+    expect(parseError({ url: "https://example.com" })).toBeNull();
+  });
+
+  it("url 未指定（null）・形式不正・非 http/https はエラー", () => {
+    // searchParams.get('url') は未指定時 null を返す
+    expect(parseError({ url: null })).toBe("url は必須です");
+    expect(parseError({ url: "not a url" })).toBe("url の形式が不正です");
+    expect(parseError({ url: "ftp://example.com" })).toBe(
+      "url は http または https のみ対応しています",
+    );
+  });
+});

--- a/src/lib/schemas/ogp.ts
+++ b/src/lib/schemas/ogp.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+import { httpUrlField } from "./common";
+
+/** OGP 取得エンドポイントの `url` クエリスキーマ（http/https 必須）。 */
+export const ogpQuerySchema = z.object({ url: httpUrlField });

--- a/src/lib/schemas/tag.test.ts
+++ b/src/lib/schemas/tag.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { firstZodError } from "./_zod-error";
+import { tagBodySchema } from "./tag";
+
+function parseError(input: unknown): string | null {
+  const r = tagBodySchema.safeParse(input);
+  return r.success ? null : firstZodError(r.error);
+}
+
+describe("tagBodySchema", () => {
+  it("正常系: name が文字列なら通過", () => {
+    const r = tagBodySchema.safeParse({ name: "React" });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.name).toBe("React");
+  });
+
+  it("name が無い・非文字列は name エラー（空/50字超の判定は lib）", () => {
+    expect(parseError({})).toBe("name は必須です");
+    expect(parseError({ name: 123 })).toBe("name は必須です");
+  });
+
+  it("空文字は通過する（空/trim/50字超は lib で判定）", () => {
+    expect(parseError({ name: "" })).toBeNull();
+  });
+
+  it("未知のキーは無視される（strip）", () => {
+    const r = tagBodySchema.safeParse({ name: "React", extra: "x" });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).not.toHaveProperty("extra");
+  });
+
+  it("body が非オブジェクト（配列・文字列・数値・null）はボディ不正の日本語エラー", () => {
+    for (const v of [[1], "x", 42, null]) {
+      expect(parseError(v)).toBe("リクエストボディが不正です");
+    }
+  });
+});

--- a/src/lib/schemas/tag.ts
+++ b/src/lib/schemas/tag.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+/**
+ * カテゴリの作成（POST）・更新（PATCH）共通の body スキーマ。
+ * route の責務は「`name` が文字列か」の検証のみ。
+ * 空・50字超・trim・重複(409) の判定は lib（`createTag`/`updateTag`）が担う。
+ */
+export const tagBodySchema = z.object(
+  { name: z.string({ error: "name は必須です" }) },
+  { error: "リクエストボディが不正です" },
+);


### PR DESCRIPTION
## 概要

T114 で導入した Zod スキーマ層を **tags・ogp エンドポイント**に展開し、検証を Zod に統合する（T115 / エピック #269）。url 検証・reorder スキーマは共有部として `common.ts` に集約した。

Closes #266

## 変更内容

- **`src/lib/schemas/common.ts`（新）**: `httpUrlField`（url の必須/形式/スキーム検証）＋ `reorderBodySchema`
  - `httpUrlField` は bookmark と ogp で共有（url 検証ロジックの重複排除）。`reorderBodySchema` は T114 で bookmark.ts にあったものを移設（bookmarks/tags 両 reorder で共有）
- **`src/lib/schemas/tag.ts`（新）**: `tagBodySchema`（`name` の文字列検証のみ。空・50字超・trim・重複(409) は lib の `createTag`/`updateTag` が担当＝現行どおり）
- **`src/lib/schemas/ogp.ts`（新）**: `ogpQuerySchema`（`url` クエリの検証）
- `src/app/api/tags/route.ts`・`[id]/route.ts`・`reorder/route.ts`・`ogp/route.ts` を `safeParse` 化
- `src/app/api/bookmarks/reorder/route.ts` を `common` からの import に変更
- スキーマテスト（common/tag/ogp）追加。bookmark.test.ts の reorder 分は common.test.ts へ移動

## 挙動の維持と小さな一貫化

- name 非文字列 → 400「name は必須です」、同名 409、空/50字超 400「タグ名が不正です」（lib）、ogp の url 3 メッセージ・取得失敗時の 200 空返しは**現行維持**
- **小変更**: 非オブジェクトの tag body は現行「name は必須です」→ Zod で「リクエストボディが不正です」に（bookmarks と一貫）

## レビュアーへの補足

- **ベースは `feature/openapi-docs`**（Phase 9 統合ブランチ）
- `httpUrlField`/`reorderBodySchema` の共有により、T114 の bookmark.ts から url 検証・reorder を common へ移設（bookmarks reorder の回帰確認済み）
- 実行時バリデーションの Zod 化まで。OpenAPI 生成は T116

## 確認

- ユニットテスト 254 件 green / biome / 型チェック src エラー 0 / 本番ビルド成功
- 開発環境（本番ビルド → `next start`）で実機 smoke：tags 作成/409/name 検証/非オブジェクト一貫化・lib のタグ名検証・reorder・**bookmarks reorder の回帰なし**・ogp（url 検証・正常取得）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)