### PR TITLE
feat: Zod スキーマから OpenAPI 3.1 仕様を生成 (T116)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ next-env.d.ts
 # prisma
 prisma/*.db
 prisma/*.db-journal
+
+# generated OpenAPI spec (T116: gen:openapi で都度生成)
+openapi.json

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "biome lint .",
     "format": "biome format --write .",
     "check": "biome check --write .",
+    "gen:openapi": "tsx scripts/gen-openapi.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",

--- a/scripts/gen-openapi.ts
+++ b/scripts/gen-openapi.ts
@@ -1,0 +1,13 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { buildOpenApiDocument } from "@/lib/openapi/document";
+
+const root = process.cwd();
+const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8")) as { version: string };
+
+const doc = buildOpenApiDocument({ version: pkg.version });
+const outPath = resolve(root, "openapi.json");
+writeFileSync(outPath, `${JSON.stringify(doc, null, 2)}\n`);
+
+console.log(`generated ${outPath} (openapi ${doc.openapi}, version ${doc.info.version})`);

--- a/src/lib/openapi/document.test.ts
+++ b/src/lib/openapi/document.test.ts
@@ -69,6 +69,15 @@ describe("buildOpenApiDocument", () => {
     );
   });
 
+  it("components.schemas に additionalProperties を残さない（実サーバーの strip 挙動と整合）", () => {
+    expect(JSON.stringify(doc.components.schemas)).not.toContain("additionalProperties");
+  });
+
+  it("url フィールドに http/https を示す description が付く", () => {
+    const bookmarkBody = JSON.parse(JSON.stringify(doc.components.schemas.BookmarkBody));
+    expect(bookmarkBody.properties.url.description).toBeTruthy();
+  });
+
   it("全 $ref が components.schemas に解決できる（参照切れなし）", () => {
     const refs = [...JSON.stringify(doc).matchAll(/"#\/components\/schemas\/([A-Za-z0-9]+)"/g)].map(
       (m) => m[1],

--- a/src/lib/openapi/document.test.ts
+++ b/src/lib/openapi/document.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { buildOpenApiDocument } from "./document";
+
+const doc = buildOpenApiDocument({ version: "9.9.9" });
+
+const EXPECTED_PATHS = [
+  "/api/bookmarks",
+  "/api/bookmarks/reorder",
+  "/api/bookmarks/trash",
+  "/api/bookmarks/{id}",
+  "/api/bookmarks/{id}/restore",
+  "/api/tags",
+  "/api/tags/reorder",
+  "/api/tags/{id}",
+  "/api/ogp",
+];
+
+const HTTP_METHODS = ["get", "post", "patch", "put", "delete"];
+
+describe("buildOpenApiDocument", () => {
+  it("OpenAPI 3.1・version・security scheme（Bearer）", () => {
+    expect(doc.openapi).toBe("3.1.0");
+    expect(doc.info.title).toBeTruthy();
+    expect(doc.info.version).toBe("9.9.9");
+    expect(doc.components.securitySchemes.bearerAuth).toMatchObject({
+      type: "http",
+      scheme: "bearer",
+    });
+    expect(doc.security).toEqual([{ bearerAuth: [] }]);
+  });
+
+  it("全エンドポイント（9 パス / 15 オペレーション）が含まれる", () => {
+    expect(Object.keys(doc.paths).sort()).toEqual([...EXPECTED_PATHS].sort());
+
+    const opCount = Object.values(doc.paths).reduce(
+      (n, item) => n + Object.keys(item).filter((k) => HTTP_METHODS.includes(k)).length,
+      0,
+    );
+    expect(opCount).toBe(15);
+  });
+
+  it("各オペレーションに summary と responses がある", () => {
+    for (const [path, item] of Object.entries(doc.paths)) {
+      for (const [method, op] of Object.entries(item as Record<string, unknown>)) {
+        if (!HTTP_METHODS.includes(method)) continue;
+        const operation = op as { summary?: string; responses?: Record<string, unknown> };
+        expect(operation.summary, `${method} ${path} summary`).toBeTruthy();
+        expect(
+          Object.keys(operation.responses ?? {}).length,
+          `${method} ${path} responses`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("components.schemas に主要スキーマがある", () => {
+    expect(Object.keys(doc.components.schemas)).toEqual(
+      expect.arrayContaining([
+        "Error",
+        "BookmarkBody",
+        "Bookmark",
+        "ReorderBody",
+        "TagBody",
+        "Tag",
+        "Ogp",
+      ]),
+    );
+  });
+
+  it("全 $ref が components.schemas に解決できる（参照切れなし）", () => {
+    const refs = [...JSON.stringify(doc).matchAll(/"#\/components\/schemas\/([A-Za-z0-9]+)"/g)].map(
+      (m) => m[1],
+    );
+    const defined = new Set(Object.keys(doc.components.schemas));
+    expect(refs.length).toBeGreaterThan(0);
+    for (const name of refs) {
+      expect(defined.has(name), `未定義スキーマ参照: ${name}`).toBe(true);
+    }
+  });
+});

--- a/src/lib/openapi/document.ts
+++ b/src/lib/openapi/document.ts
@@ -1,0 +1,284 @@
+import { z } from "zod";
+
+import { bookmarkBodySchema, bookmarkResponseSchema } from "@/lib/schemas/bookmark";
+import { errorResponseSchema, reorderBodySchema } from "@/lib/schemas/common";
+import { ogpResponseSchema } from "@/lib/schemas/ogp";
+import { tagBodySchema, tagResponseSchema } from "@/lib/schemas/tag";
+
+/** Zod スキーマを OpenAPI 3.1（JSON Schema 2020-12）に変換する。`$schema` は components では不要なため除去。 */
+function toSchema(schema: z.ZodType): Record<string, unknown> {
+  const json = z.toJSONSchema(schema) as Record<string, unknown>;
+  delete json.$schema;
+  return json;
+}
+
+const ref = (name: string) => ({ $ref: `#/components/schemas/${name}` });
+
+/** JSON レスポンス定義。 */
+const jsonResponse = (description: string, schema: object) => ({
+  description,
+  content: { "application/json": { schema } },
+});
+
+/** `{ error }` を返す 4xx レスポンス定義。 */
+const errorResponse = (description: string) => jsonResponse(description, ref("Error"));
+
+/** JSON リクエストボディ定義。 */
+const jsonBody = (name: string) => ({
+  required: true,
+  content: { "application/json": { schema: ref(name) } },
+});
+
+const idParam = {
+  name: "id",
+  in: "path",
+  required: true,
+  schema: { type: "string" },
+  description: "対象リソースの ID",
+};
+
+/** OpenAPI 3.1 ドキュメントを組み立てる。 */
+export function buildOpenApiDocument(options: { version?: string } = {}) {
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "link-hub API",
+      version: options.version ?? "0.0.0",
+      description:
+        "link-hub の外部 REST API。API キー（`Authorization: Bearer <api-key>`）で認証する。",
+    },
+    servers: [{ url: "http://localhost:3000", description: "ローカル開発" }],
+    security: [{ bearerAuth: [] }],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          description: "設定モーダルで発行した API キー",
+        },
+      },
+      schemas: {
+        Error: toSchema(errorResponseSchema),
+        BookmarkBody: toSchema(bookmarkBodySchema),
+        Bookmark: toSchema(bookmarkResponseSchema),
+        ReorderBody: toSchema(reorderBodySchema),
+        TagBody: toSchema(tagBodySchema),
+        Tag: toSchema(tagResponseSchema),
+        Ogp: toSchema(ogpResponseSchema),
+      },
+    },
+    paths: {
+      "/api/bookmarks": {
+        get: {
+          summary: "ブックマーク一覧を取得",
+          tags: ["bookmarks"],
+          responses: {
+            200: jsonResponse("未削除ブックマークの一覧", {
+              type: "object",
+              properties: { bookmarks: { type: "array", items: ref("Bookmark") } },
+              required: ["bookmarks"],
+            }),
+            401: errorResponse("認証エラー"),
+          },
+        },
+        post: {
+          summary: "ブックマークを作成",
+          tags: ["bookmarks"],
+          requestBody: jsonBody("BookmarkBody"),
+          responses: {
+            201: jsonResponse("作成されたブックマーク", ref("Bookmark")),
+            400: errorResponse("バリデーションエラー"),
+            401: errorResponse("認証エラー"),
+            404: errorResponse("指定した tagId のカテゴリが存在しない"),
+          },
+        },
+        delete: {
+          summary: "複数ブックマークを一括削除（ゴミ箱へ）",
+          tags: ["bookmarks"],
+          parameters: [
+            {
+              name: "ids",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+              description: "カンマ区切りの ID",
+            },
+          ],
+          responses: {
+            204: { description: "削除成功（ボディなし）" },
+            400: errorResponse("ids 未指定"),
+            401: errorResponse("認証エラー"),
+          },
+        },
+      },
+      "/api/bookmarks/reorder": {
+        post: {
+          summary: "ブックマークの並び順を一括更新",
+          tags: ["bookmarks"],
+          requestBody: jsonBody("ReorderBody"),
+          responses: {
+            200: { description: "並び替え成功（ボディなし）" },
+            400: errorResponse("ids 不正"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("他ユーザーの ID を含む"),
+          },
+        },
+      },
+      "/api/bookmarks/trash": {
+        get: {
+          summary: "ゴミ箱（削除済み）一覧を取得",
+          tags: ["bookmarks"],
+          responses: {
+            200: jsonResponse("削除済みブックマークの一覧", {
+              type: "object",
+              properties: { bookmarks: { type: "array", items: ref("Bookmark") } },
+              required: ["bookmarks"],
+            }),
+            401: errorResponse("認証エラー"),
+          },
+        },
+        delete: {
+          summary: "ゴミ箱を空にする（完全削除）",
+          tags: ["bookmarks"],
+          responses: {
+            204: { description: "完全削除成功（ボディなし）" },
+            401: errorResponse("認証エラー"),
+          },
+        },
+      },
+      "/api/bookmarks/{id}": {
+        patch: {
+          summary: "ブックマークを更新（カテゴリ移動・並び順変更を含む）",
+          tags: ["bookmarks"],
+          parameters: [idParam],
+          requestBody: jsonBody("BookmarkBody"),
+          responses: {
+            200: jsonResponse("更新後のブックマーク", ref("Bookmark")),
+            400: errorResponse("バリデーションエラー"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("他ユーザーのリソース"),
+            404: errorResponse("未存在 / 指定した tagId のカテゴリが存在しない"),
+          },
+        },
+        delete: {
+          summary: "ブックマークを削除（ゴミ箱へ）",
+          tags: ["bookmarks"],
+          parameters: [idParam],
+          responses: {
+            204: { description: "削除成功（ボディなし）" },
+            401: errorResponse("認証エラー"),
+            403: errorResponse("他ユーザーのリソース"),
+            404: errorResponse("未存在"),
+          },
+        },
+      },
+      "/api/bookmarks/{id}/restore": {
+        post: {
+          summary: "ゴミ箱から復元",
+          tags: ["bookmarks"],
+          parameters: [idParam],
+          responses: {
+            200: jsonResponse("復元後のブックマーク", ref("Bookmark")),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("他ユーザーのリソース"),
+            404: errorResponse("未存在"),
+          },
+        },
+      },
+      "/api/tags": {
+        get: {
+          summary: "カテゴリ一覧を取得",
+          tags: ["tags"],
+          parameters: [
+            {
+              name: "withCount",
+              in: "query",
+              required: false,
+              schema: { type: "string", enum: ["true"] },
+              description: "`true` で各カテゴリの未削除ブックマーク件数を含める",
+            },
+          ],
+          responses: {
+            200: jsonResponse("カテゴリの一覧", {
+              type: "object",
+              properties: { tags: { type: "array", items: ref("Tag") } },
+              required: ["tags"],
+            }),
+            401: errorResponse("認証エラー"),
+          },
+        },
+        post: {
+          summary: "カテゴリを作成",
+          tags: ["tags"],
+          requestBody: jsonBody("TagBody"),
+          responses: {
+            201: jsonResponse("作成されたカテゴリ", ref("Tag")),
+            400: errorResponse("バリデーションエラー"),
+            401: errorResponse("認証エラー"),
+            409: errorResponse("同名カテゴリが既に存在"),
+          },
+        },
+      },
+      "/api/tags/reorder": {
+        post: {
+          summary: "カテゴリの並び順を一括更新",
+          tags: ["tags"],
+          requestBody: jsonBody("ReorderBody"),
+          responses: {
+            200: { description: "並び替え成功（ボディなし）" },
+            400: errorResponse("ids 不正"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("他ユーザーの ID を含む"),
+          },
+        },
+      },
+      "/api/tags/{id}": {
+        patch: {
+          summary: "カテゴリ名を変更",
+          tags: ["tags"],
+          parameters: [idParam],
+          requestBody: jsonBody("TagBody"),
+          responses: {
+            200: jsonResponse("更新後のカテゴリ", ref("Tag")),
+            400: errorResponse("バリデーションエラー"),
+            401: errorResponse("認証エラー"),
+            403: errorResponse("他ユーザーのリソース"),
+            404: errorResponse("未存在"),
+            409: errorResponse("同名カテゴリが既に存在"),
+          },
+        },
+        delete: {
+          summary: "カテゴリを削除（紐づくブックマークは未分類化）",
+          tags: ["tags"],
+          parameters: [idParam],
+          responses: {
+            204: { description: "削除成功（ボディなし）" },
+            401: errorResponse("認証エラー"),
+            403: errorResponse("他ユーザーのリソース"),
+            404: errorResponse("未存在"),
+          },
+        },
+      },
+      "/api/ogp": {
+        get: {
+          summary: "指定 URL の OGP メタデータを取得",
+          tags: ["ogp"],
+          parameters: [
+            {
+              name: "url",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+              description: "http/https の URL",
+            },
+          ],
+          responses: {
+            200: jsonResponse("OGP メタデータ（取得失敗時も 200 で null）", ref("Ogp")),
+            400: errorResponse("url 未指定・形式不正"),
+            401: errorResponse("認証エラー"),
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/lib/openapi/document.ts
+++ b/src/lib/openapi/document.ts
@@ -5,10 +5,29 @@ import { errorResponseSchema, reorderBodySchema } from "@/lib/schemas/common";
 import { ogpResponseSchema } from "@/lib/schemas/ogp";
 import { tagBodySchema, tagResponseSchema } from "@/lib/schemas/tag";
 
-/** Zod スキーマを OpenAPI 3.1（JSON Schema 2020-12）に変換する。`$schema` は components では不要なため除去。 */
+/**
+ * `additionalProperties` を再帰的に除去する。
+ * Zod の `z.object()` は既定で strip（未知キーは受理して無視）だが `z.toJSONSchema()` は
+ * `additionalProperties: false` を出力するため、これを残すと「未知フィールドは拒否」と読めて
+ * 実サーバー挙動（受理して無視）と食い違う。仕様を実挙動に合わせるため除去する。
+ */
+function stripAdditionalProperties(node: unknown): void {
+  if (Array.isArray(node)) {
+    for (const item of node) stripAdditionalProperties(item);
+    return;
+  }
+  if (node && typeof node === "object") {
+    const obj = node as Record<string, unknown>;
+    delete obj.additionalProperties;
+    for (const value of Object.values(obj)) stripAdditionalProperties(value);
+  }
+}
+
+/** Zod スキーマを OpenAPI 3.1（JSON Schema 2020-12）に変換する。`$schema`・`additionalProperties` は除去。 */
 function toSchema(schema: z.ZodType): Record<string, unknown> {
   const json = z.toJSONSchema(schema) as Record<string, unknown>;
   delete json.$schema;
+  stripAdditionalProperties(json);
   return json;
 }
 
@@ -194,8 +213,9 @@ export function buildOpenApiDocument(options: { version?: string } = {}) {
               name: "withCount",
               in: "query",
               required: false,
-              schema: { type: "string", enum: ["true"] },
-              description: "`true` で各カテゴリの未削除ブックマーク件数を含める",
+              schema: { type: "string" },
+              description:
+                "`true` のとき各カテゴリの未削除ブックマーク件数を含める（それ以外の値は件数なし）",
             },
           ],
           responses: {

--- a/src/lib/schemas/bookmark.ts
+++ b/src/lib/schemas/bookmark.ts
@@ -36,4 +36,15 @@ export const bookmarkBodySchema = z.object(
 
 export type BookmarkBody = z.infer<typeof bookmarkBodySchema>;
 
+/** ブックマークのレスポンス形式（OpenAPI ドキュメント用）。 */
+export const bookmarkResponseSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  title: z.string(),
+  memo: z.string().nullable(),
+  ogImage: z.string().nullable(),
+  category: z.object({ id: z.string(), name: z.string() }).nullable(),
+  createdAt: z.string(),
+});
+
 // 並び替え（reorder）の body スキーマは共通のため src/lib/schemas/common.ts に移設。

--- a/src/lib/schemas/common.ts
+++ b/src/lib/schemas/common.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+/** エラーレスポンス `{ error: string }`（OpenAPI ドキュメント用）。 */
+export const errorResponseSchema = z.object({ error: z.string() });
+
 /**
  * http/https の URL を検証する共有フィールド（必須/形式/スキームの 3 メッセージ）。
  * ブックマークの `url` と OGP 取得の `url` クエリで共有する。

--- a/src/lib/schemas/common.ts
+++ b/src/lib/schemas/common.ts
@@ -7,22 +7,25 @@ export const errorResponseSchema = z.object({ error: z.string() });
  * http/https の URL を検証する共有フィールド（必須/形式/スキームの 3 メッセージ）。
  * ブックマークの `url` と OGP 取得の `url` クエリで共有する。
  */
-export const httpUrlField = z.string({ error: "url は必須です" }).superRefine((val, ctx) => {
-  if (val.trim() === "") {
-    ctx.addIssue({ code: "custom", message: "url は必須です" });
-    return;
-  }
-  let parsed: URL;
-  try {
-    parsed = new URL(val);
-  } catch {
-    ctx.addIssue({ code: "custom", message: "url の形式が不正です" });
-    return;
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    ctx.addIssue({ code: "custom", message: "url は http または https のみ対応しています" });
-  }
-});
+export const httpUrlField = z
+  .string({ error: "url は必須です" })
+  .superRefine((val, ctx) => {
+    if (val.trim() === "") {
+      ctx.addIssue({ code: "custom", message: "url は必須です" });
+      return;
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(val);
+    } catch {
+      ctx.addIssue({ code: "custom", message: "url の形式が不正です" });
+      return;
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      ctx.addIssue({ code: "custom", message: "url は http または https のみ対応しています" });
+    }
+  })
+  .meta({ description: "http または https の URL" });
 
 /**
  * 並び替え（reorder）の body スキーマ（ブックマーク・カテゴリ共通）。

--- a/src/lib/schemas/ogp.ts
+++ b/src/lib/schemas/ogp.ts
@@ -4,3 +4,9 @@ import { httpUrlField } from "./common";
 
 /** OGP 取得エンドポイントの `url` クエリスキーマ（http/https 必須）。 */
 export const ogpQuerySchema = z.object({ url: httpUrlField });
+
+/** OGP 取得のレスポンス形式（取得できなければ null）。 */
+export const ogpResponseSchema = z.object({
+  title: z.string().nullable(),
+  image: z.string().nullable(),
+});

--- a/src/lib/schemas/tag.ts
+++ b/src/lib/schemas/tag.ts
@@ -9,3 +9,10 @@ export const tagBodySchema = z.object(
   { name: z.string({ error: "name は必須です" }) },
   { error: "リクエストボディが不正です" },
 );
+
+/** カテゴリのレスポンス形式（`?withCount=true` 時のみ `bookmarkCount`）。 */
+export const tagResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  bookmarkCount: z.number().int().optional(),
+});


### PR DESCRIPTION
## 概要

Zod スキーマを「唯一の正」として **OpenAPI 3.1 仕様を生成**する仕組みを追加する（T116 / エピック #269）。実行時バリデーションと同じスキーマから仕様が導出されるため drift しない。

Closes #267

## 変更内容

- **レスポンススキーマ追加**（`src/lib/schemas/*`）: `bookmarkResponseSchema`・`tagResponseSchema`・`ogpResponseSchema`・`errorResponseSchema`（OpenAPI ドキュメント用）
- **`src/lib/openapi/document.ts`**: `buildOpenApiDocument()`
  - `z.toJSONSchema()`（Zod 4 標準・JSON Schema 2020-12 ＝ OpenAPI 3.1 と整合）で `components.schemas` を生成
  - 9 パス / 15 オペレーション（bookmarks・tags・ogp）を登録、`components.securitySchemes.bearerAuth`（`type: http, scheme: bearer`）を global `security` に
- **`scripts/gen-openapi.ts` ＋ `npm run gen:openapi`**: `openapi.json`（`info.version` は package.json 由来）を生成。生成物は **gitignore**（公開用は T117 の Actions で都度生成）
- **`src/lib/openapi/document.test.ts`**: 全パス/オペレーション・`securityScheme`・`components`・**`$ref` 参照切れなし**を検証

## レビュアーへの補足（方針変更）

- 計画では `@redocly/cli` で CI spec lint 予定でしたが、**この開発環境（Windows マウントの Docker）で追加バイナリ依存の `npm install` が権限エラーで失敗**したため、**redocly を採用せず dependency-free のユニットテストで spec を検証**する方針に変更しました。
  - 検証は `npm test`（CI が develop/master 宛 PR で実行）に載るため、「CI で spec を検証する」意図は満たします
  - 参照切れ・必須欠落・全エンドポイント網羅を hand-written でカバー。将来 Ubuntu ベースの CI 上で本格 linter（redocly 等）を足すことも可能です
- **ベースは `feature/openapi-docs`**（Phase 9 統合ブランチ）
- ランタイム挙動・API レスポンスは不変（ドキュメント生成のみ）。公開（Scalar/Pages）は T117

## 確認

- ユニットテスト 259 件 green / biome / 型チェック src エラー 0
- `npm run gen:openapi` で `openapi.json`（3.1.0・9 パス・bearerAuth・nullable/required 反映）生成を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)