### PR TITLE
feat: REST API の CORS 対応 (T118)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,7 @@
 - リクエスト・レスポンスボディはすべて JSON（`Content-Type: application/json`）
 - 削除はソフトデリート（ゴミ箱へ移動）。ゴミ箱の一覧・復元・完全削除を別途提供
 - 未知のリクエストフィールドは受理して無視する（strip）
+- **CORS 対応**: 任意オリジンから利用可（`Access-Control-Allow-Origin: *`）。API キー認証・Cookie 不使用のためオリジン制限は不要。プリフライト `OPTIONS` にも対応（`src/proxy.ts`）
 
 ### エラーレスポンス
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,17 +1,34 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
-const isPublicRoute = createRouteMatcher([
-  "/sign-in(.*)",
-  "/sign-up(.*)",
-  "/auth-error",
-  // 外部連携用 REST API は Clerk ではなく API キー認証で保護する
-  "/api/bookmarks(.*)",
-  "/api/tags(.*)",
-  "/api/ogp(.*)",
-]);
+const isPublicRoute = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)", "/auth-error"]);
+
+// 外部連携用 REST API（Clerk ではなく API キー認証で保護）。CORS 対応の対象でもある。
+const isApiRoute = createRouteMatcher(["/api/bookmarks(.*)", "/api/tags(.*)", "/api/ogp(.*)"]);
+
+// API キー認証（Authorization ヘッダ）・Cookie 不使用のため、任意オリジン許可（*）で安全。
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers": "Authorization, Content-Type",
+  "Access-Control-Max-Age": "86400",
+};
+
+function withCors(res: NextResponse): NextResponse {
+  for (const [key, value] of Object.entries(CORS_HEADERS)) res.headers.set(key, value);
+  return res;
+}
 
 export default clerkMiddleware(async (auth, request) => {
+  // 外部連携 API は CORS 対応。プリフライトは認証不要で 204 を返し、通常応答にも CORS を付与する。
+  // 認証は各ルートの API キー検証に委ねる（Clerk 保護対象外）。
+  if (isApiRoute(request)) {
+    if (request.method === "OPTIONS") {
+      return withCors(new NextResponse(null, { status: 204 }));
+    }
+    return withCors(NextResponse.next());
+  }
+
   // 開発環境でのモックユーザーによる認証バイパス
   if (
     process.env.NODE_ENV !== "production" &&


### PR DESCRIPTION
## 概要

公開 API リファレンス（Scalar / GitHub Pages）の「Try it out」や外部オリジンのフロントから REST API（`/api/bookmarks`・`/api/tags`・`/api/ogp`）を叩けるよう **CORS 対応**する（T118）。

Closes #275

## 変更内容

- **`src/proxy.ts`**（middleware）: 対象 API ルートに CORS 対応
  - プリフライト `OPTIONS` は認証不要で `204` ＋ CORS ヘッダを返す
  - 通常レスポンス（成功・エラーとも）に CORS ヘッダを付与
  - ヘッダ: `Access-Control-Allow-Origin: *` / `Access-Control-Allow-Methods: GET, POST, PATCH, DELETE, OPTIONS` / `Access-Control-Allow-Headers: Authorization, Content-Type` / `Access-Control-Max-Age: 86400`
  - 認証（API キー / Clerk 保護）・開発モックバイパスは不変。API 以外のルートは従来どおり
- **`docs/api.md`**: 共通仕様に CORS を追記

## なぜ `Allow-Origin: *` で安全か

API は **`Authorization: Bearer`（API キー）認証・Cookie 不使用**。キーがなければ 401 で弾かれ、Cookie 認証のような CSRF リスクがない（ブラウザは他サイトのキーを勝手に送れない）。GitHub / Stripe 等の外部 API と同じく、トークン認証 API では `*` が標準的で安全。

## 確認

- biome / 型チェック src エラー 0 / ユニットテスト 262 件 green
- 開発環境（本番ビルド → `next start`）で実機確認:
  - `OPTIONS /api/bookmarks` → `204` ＋ 全 CORS ヘッダ
  - キーなし GET → `401` ＋ `Access-Control-Allow-Origin: *`（エラー応答にも付与）
  - 有効キー GET → `200` ＋ CORS
  - `/api/tags`・`/api/ogp` の `OPTIONS` → `204`
  - **保護ルート `/` → `307` sign-in リダイレクト・CORS なし（Clerk 認証は不変）**

> middleware は Clerk ラップのためユニットテストが難しく、CORS/認証の検証は実機（curl）で担保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)