### PR TITLE
fix: seed の Clerk ガードを fail-fast に統一

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -15,7 +15,10 @@ dotenv.config({ path: ".env" });
 const adapter = new PrismaNeon({ connectionString: process.env.DIRECT_URL ?? "" });
 const prisma = new PrismaClient({ adapter });
 
-const clerk = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY });
+const clerkSecretKey = process.env.CLERK_SECRET_KEY;
+if (!clerkSecretKey) throw new Error("CLERK_SECRET_KEY is not set");
+
+const clerk = createClerkClient({ secretKey: clerkSecretKey });
 
 // テストユーザーの共通パスワード
 const SEED_PASSWORD = "Yakitori2026";


### PR DESCRIPTION
Closes #282

seed は開発/テスト用（手動実行のみ）。`CLERK_SECRET_KEY` 未設定でも client を生成し、後続の Clerk API 呼び出しで不明瞭に失敗していたのを、**冒頭で明示 throw する fail-fast** に変更。

link-hub は `clerkId` が schema 上**必須（`String`・非null）**で graceful スキップ（null 挿入）ができないため、daily/eval の graceful スキップとは実装が異なるが、「`CLERK_SECRET_KEY` 未設定を明示的に扱う」点で3リポ揃える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)