### PR TITLE
[T127] Dependabot の TypeScript 7（ネイティブ版）更新を抑止

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
         dependency-type: production
       development-dependencies:
         dependency-type: development
+    ignore:
+      # TypeScript 7 はネイティブ版（Go 実装）で Next.js 16 の build と非互換。
+      # Next.js がネイティブ版に対応するまでメジャー更新を保留する。
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: devcontainers
     directory: /


### PR DESCRIPTION
## 概要

Dependabot による `typescript` の **メジャー更新（`^6` → `^7`）を抑止**する。

TypeScript 7.0 系はネイティブ版（Go 実装 / tsgo）で、従来型 `typescript` パッケージ構造を前提とする **Next.js 16.2.10 の `next build`（TypeScript チェック）と非互換**。実際に Vercel ビルドが失敗している（PR #293）。

Closes #294

## 変更

`.github/dependabot.yml` の npm ブロックに `ignore` を追加：
- `typescript` の `version-update:semver-major` を無視
- 6 系のマイナー/パッチ更新は引き続き受け入れる
- Next.js がネイティブ版に対応したら ignore を外す

## マージ後の手順

PR #293 に `@dependabot recreate` をコメントし、typescript を除いた4件（biome 2.5.3 / tsx 4.23.1 / vitest 4.1.10）で再生成 → マージ。

## 関連

daily-hub / eval-hub も同条件（Next 16.2.10・`typescript ^6`・同一 dependabot.yml）。別途同じ対応が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
